### PR TITLE
Fix links in Kotlin install instructions

### DIFF
--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -52,11 +52,10 @@ repositories {
 }
 
 dependencies {
-  implementation("breez_sdk:bindings-android:<version>")
+  implementation("breez_sdk_liquid:bindings-android:<version>")
 }
 ```
 
-See [the example](https://github.com/breez/breez-sdk-examples/tree/main/Android) for more details
 
 ## React Native
 


### PR DESCRIPTION
This PR fixes a typo in a link and removes the examples link, as it's not applicable to the Liquid integration.