### PR TITLE
Expand Sending Payments page

### DIFF
--- a/snippets/csharp/ReceivePayment.cs
+++ b/snippets/csharp/ReceivePayment.cs
@@ -18,6 +18,7 @@ public class ReceivePaymentSnippets
 
             // If the fees are acceptable, continue to create the Receive Payment
             var receiveFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {receiveFeesSat} sats");
         }
         catch (Exception)
         {
@@ -42,6 +43,7 @@ public class ReceivePaymentSnippets
 
             // If the fees are acceptable, continue to create the Receive Payment
             var receiveFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {receiveFeesSat} sats");
         }
         catch (Exception)
         {
@@ -63,6 +65,7 @@ public class ReceivePaymentSnippets
 
             // If the fees are acceptable, continue to create the Receive Payment
             var receiveFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {receiveFeesSat} sats");
         }
         catch (Exception)
         {

--- a/snippets/csharp/SendPayment.cs
+++ b/snippets/csharp/SendPayment.cs
@@ -2,11 +2,30 @@ using Breez.Sdk.Liquid;
 
 public class SendPaymentSnippets
 {
-    public void SendPayment(BindingLiquidSdk sdk)
+    public void PrepareSendPaymentLightning(BindingLiquidSdk sdk)
     {
-        // ANCHOR: send-payment
-        // Set the BOLT11 invoice you wish to pay
-        var destination = "Invoice, Liquid BIP21 or address";
+        // ANCHOR: prepare-send-payment-lightning
+        // Set the bolt11 invoice you wish to pay
+        var destination = "<bolt11 invoice>";
+        try
+        {
+            var prepareResponse = sdk.PrepareSendPayment(new PrepareSendRequest(destination));
+
+            // If the fees are acceptable, continue to create the Send Payment
+            var sendFeesSat = prepareResponse.feesSat;
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: prepare-send-payment-lightning
+    }
+
+    public void PrepareSendPaymentLiquid(BindingLiquidSdk sdk)
+    {
+        // ANCHOR: prepare-send-payment-liquid
+        // Set the Liquid BIP21 or address you wish to pay
+        var destination = "<Liquid BIP21 or address>";
         try
         {
             ulong optionalAmountSat = 5000;
@@ -14,7 +33,19 @@ public class SendPaymentSnippets
 
             // If the fees are acceptable, continue to create the Send Payment
             var sendFeesSat = prepareResponse.feesSat;
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: prepare-send-payment-liquid
+    }
 
+    public void SendPayment(BindingLiquidSdk sdk, PrepareSendResponse prepareResponse)
+    {
+        // ANCHOR: send-payment
+        try
+        {
             var sendResponse = sdk.SendPayment(new SendPaymentRequest(prepareResponse));
             var payment = sendResponse.payment;
         }
@@ -23,5 +54,4 @@ public class SendPaymentSnippets
             // Handle error
         }
         // ANCHOR_END: send-payment
-    }
-}
+    }}

--- a/snippets/csharp/SendPayment.cs
+++ b/snippets/csharp/SendPayment.cs
@@ -13,6 +13,7 @@ public class SendPaymentSnippets
 
             // If the fees are acceptable, continue to create the Send Payment
             var sendFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {sendFeesSat} sats");
         }
         catch (Exception)
         {
@@ -33,6 +34,7 @@ public class SendPaymentSnippets
 
             // If the fees are acceptable, continue to create the Send Payment
             var sendFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {sendFeesSat} sats");
         }
         catch (Exception)
         {

--- a/snippets/dart_snippets/lib/receive_payment.dart
+++ b/snippets/dart_snippets/lib/receive_payment.dart
@@ -20,9 +20,8 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLightning() async {
 
   // If the fees are acceptable, continue to create the Receive Payment
   BigInt receiveFeesSat = prepareResponse.feesSat;
+  print("Fees: ${receiveFeesSat} sats");
   // ANCHOR_END: prepare-receive-payment-lightning
-
-  print(receiveFeesSat);
   return prepareResponse;
 }
 
@@ -45,9 +44,8 @@ Future<PrepareReceiveResponse> prepareReceivePaymentOnchain() async {
 
   // If the fees are acceptable, continue to create the Receive Payment
   BigInt receiveFeesSat = prepareResponse.feesSat;
+  print("Fees: ${receiveFeesSat} sats");
   // ANCHOR_END: prepare-receive-payment-onchain
-
-  print(receiveFeesSat);
   return prepareResponse;
 }
 
@@ -66,9 +64,8 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLiquid() async {
 
   // If the fees are acceptable, continue to create the Receive Payment
   BigInt receiveFeesSat = prepareResponse.feesSat;
+  print("Fees: ${receiveFeesSat} sats");
   // ANCHOR_END: prepare-receive-payment-liquid
-
-  print(receiveFeesSat);
   return prepareResponse;
 }
 
@@ -85,7 +82,6 @@ Future<ReceivePaymentResponse> receivePayment(
 
   String destination = res.destination;
   // ANCHOR_END: receive-payment
-
   print(destination);
   return res;
 }

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -10,8 +10,8 @@ Future<PrepareSendResponse> prepareSendPaymentLightning() async {
 
   // If the fees are acceptable, continue to create the Send Payment
   BigInt sendFeesSat = prepareSendResponse.feesSat;
+  print("Fees: ${sendFeesSat} sats");
   // ANCHOR_END: prepare-send-payment-lightning
-  print(sendFeesSat);
   return prepareSendResponse;
 }
 
@@ -26,8 +26,8 @@ Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
 
   // If the fees are acceptable, continue to create the Send Payment
   BigInt sendFeesSat = prepareSendResponse.feesSat;
+  print("Fees: ${sendFeesSat} sats");
   // ANCHOR_END: prepare-send-payment-liquid
-  print(sendFeesSat);
   return prepareSendResponse;
 }
 
@@ -38,7 +38,6 @@ Future<SendPaymentResponse> sendPayment({required PrepareSendResponse prepareRes
   );
   Payment payment = sendPaymentResponse.payment;
   // ANCHOR_END: send-payment
-  print(sendFeesSat);
   print(payment);
   return sendPaymentResponse;
 }

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -1,19 +1,40 @@
 import 'package:dart_snippets/sdk_instance.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
-Future<SendPaymentResponse> sendPayment({required String bolt11}) async {
-  // ANCHOR: send-payment
-  // Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmountSat = BigInt.from(2000);
+Future<PrepareSendResponse> prepareSendPaymentLightning() async {
+  // ANCHOR: prepare-send-payment-lightning
+  // Set the bolt11 invoice you wish to pay
   PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
-    req: PrepareSendRequest(destination: "Invoice, Liquid BIP21 or address", amountSat: optionalAmountSat),
+    req: PrepareSendRequest(destination: "<bolt11 invoice>"),
   );
 
   // If the fees are acceptable, continue to create the Send Payment
   BigInt sendFeesSat = prepareSendResponse.feesSat;
+  // ANCHOR_END: prepare-send-payment-lightning
+  print(sendFeesSat);
+  return prepareSendResponse;
+}
 
+Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
+  // ANCHOR: prepare-send-payment-liquid
+  // Set the Liquid BIP21 or Liquid address you wish to pay
+  BigInt optionalAmountSat = BigInt.from(5000);
+
+  PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
+    req: PrepareSendRequest(destination: "<Liquid BIP21 or address>", amountSat: optionalAmountSat),
+  );
+
+  // If the fees are acceptable, continue to create the Send Payment
+  BigInt sendFeesSat = prepareSendResponse.feesSat;
+  // ANCHOR_END: prepare-send-payment-liquid
+  print(sendFeesSat);
+  return prepareSendResponse;
+}
+
+Future<SendPaymentResponse> sendPayment({required PrepareSendResponse prepareResponse}) async {
+  // ANCHOR: send-payment
   SendPaymentResponse sendPaymentResponse = await breezSDKLiquid.instance!.sendPayment(
-    req: SendPaymentRequest(prepareResponse: prepareSendResponse),
+    req: SendPaymentRequest(prepareResponse: prepareResponse),
   );
   Payment payment = sendPaymentResponse.payment;
   // ANCHOR_END: send-payment

--- a/snippets/go/send_payment.go
+++ b/snippets/go/send_payment.go
@@ -6,10 +6,28 @@ import (
 	"github.com/breez/breez-sdk-liquid-go/breez_sdk_liquid"
 )
 
-func SendPayment(sdk *breez_sdk_liquid.BindingLiquidSdk) {
-	// ANCHOR: send-payment
-	// Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
-	destination := "Invoice, Liquid BIP21 or address"
+func PrepareSendPaymentLightning(sdk *breez_sdk_liquid.BindingLiquidSdk) {
+	// ANCHOR: prepare-send-payment-lightning
+	// Set the bolt11 invoice you wish to pay
+	destination := "<bolt11 invoice>"
+	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
+		Destination: destination,
+	}
+	prepareResponse, err := sdk.PrepareSendPayment(prepareRequest)
+	if err != nil {
+		log.Printf("Error: %#v", err)
+		return
+	}
+
+	sendFeesSat := prepareResponse.FeesSat
+	log.Printf("Fees: %v sats", sendFeesSat)
+	// ANCHOR_END: prepare-send-payment-lightning
+}
+
+func PrepareSendPaymentLiquid(sdk *breez_sdk_liquid.BindingLiquidSdk) {
+	// ANCHOR: prepare-send-payment-liquid
+	// Set the Liquid BIP21 or Liquid address you wish to pay
+	destination := "<Liquid BIP21 or address>"
 	optionalAmountSat := uint64(5_000)
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,
@@ -23,7 +41,11 @@ func SendPayment(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 
 	sendFeesSat := prepareResponse.FeesSat
 	log.Printf("Fees: %v sats", sendFeesSat)
+	// ANCHOR_END: prepare-send-payment-liquid
+}
 
+func SendPayment(sdk *breez_sdk_liquid.BindingLiquidSdk, prepareResponse breez_sdk_liquid.PrepareSendResponse) {
+	// ANCHOR: send-payment
 	req := breez_sdk_liquid.SendPaymentRequest{
 		PrepareResponse: prepareResponse,
 	}

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ReceivePayment.kt
@@ -15,7 +15,8 @@ class ReceivePayment {
             val prepareResponse = sdk.prepareReceivePayment(prepareRequest)
 
             // If the fees are acceptable, continue to create the Receive Payment
-            val receiveFeesSat =  prepareResponse.feesSat;
+            val receiveFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${receiveFeesSat} sats")
         } catch (e: Exception) {
             // handle error
         }
@@ -35,7 +36,8 @@ class ReceivePayment {
             val prepareResponse = sdk.prepareReceivePayment(prepareRequest)
 
             // If the fees are acceptable, continue to create the Receive Payment
-            val receiveFeesSat =  prepareResponse.feesSat;
+            val receiveFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${receiveFeesSat} sats")
         } catch (e: Exception) {
             // handle error
         }
@@ -52,7 +54,8 @@ class ReceivePayment {
             val prepareResponse = sdk.prepareReceivePayment(prepareRequest)
 
             // If the fees are acceptable, continue to create the Receive Payment
-            val receiveFeesSat =  prepareResponse.feesSat;
+            val receiveFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${receiveFeesSat} sats")
         } catch (e: Exception) {
             // handle error
         }

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -12,6 +12,7 @@ class SendPayment {
 
             // If the fees are acceptable, continue to create the Send Payment
             val sendFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${sendFeesSat} sats")
         } catch (e: Exception) {
             // handle error
         }
@@ -28,6 +29,7 @@ class SendPayment {
 
             // If the fees are acceptable, continue to create the Send Payment
             val sendFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${sendFeesSat} sats")
         } catch (e: Exception) {
             // handle error
         }

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -1,18 +1,42 @@
 package com.example.kotlinmpplib
 
 import breez_sdk_liquid.*
+
 class SendPayment {
-    fun sendPayment(sdk: BindingLiquidSdk) {
-        // ANCHOR: send-payment
-        // Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
-        val destination = "Invoice, Liquid BIP21 or address"
+    fun prepareSendPaymentLightning(sdk: BindingLiquidSdk) {
+        // ANCHOR: prepare-send-payment-lightning
+        // Set the bolt11 you wish to pay
+        val destination = "<bolt11 invoice>"
+        try {
+            val prepareResponse = sdk.prepareSendPayment(PrepareSendRequest(destination))
+
+            // If the fees are acceptable, continue to create the Send Payment
+            val sendFeesSat = prepareResponse.feesSat;
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: prepare-send-payment-lightning
+    }
+
+    fun prepareSendPaymentLiquid(sdk: BindingLiquidSdk) {
+        // ANCHOR: prepare-send-payment-liquid
+        // Set the Liquid BIP21 or Liquid address you wish to pay
+        val destination = "<Liquid BIP21 or address>"
         try {
             val optionalAmountSat = 5_000.toULong();
             val prepareResponse = sdk.prepareSendPayment(PrepareSendRequest(destination, optionalAmountSat))
 
             // If the fees are acceptable, continue to create the Send Payment
             val sendFeesSat = prepareResponse.feesSat;
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: prepare-send-payment-liquid
+    }
 
+    fun sendPayment(sdk: BindingLiquidSdk, prepareResponse: PrepareSendResponse) {
+        // ANCHOR: send-payment
+        try {
             val sendResponse = sdk.sendPayment(SendPaymentRequest(prepareResponse))
             val payment = sendResponse.payment
         } catch (e: Exception) {

--- a/snippets/python/main.py
+++ b/snippets/python/main.py
@@ -9,7 +9,7 @@ from src.lnurl_withdraw import withdraw
 from src.pay_onchain import fetch_pay_onchain_limits, prepare_pay_onchain, prepare_pay_onchain_fee_rate, start_pay_onchain
 from src.receive_onchain import list_refundables, execute_refund, rescan_swaps
 from src.receive_payment import prepare_receive_lightning, prepare_receive_onchain, prepare_receive_liquid, receive_payment
-from src.send_payment import send_payment
+from src.send_payment import prepare_send_payment_lightning, prepare_send_payment_liquid, send_payment
 from src.webhook import register_webhook, unregister_webhook
 
 
@@ -57,7 +57,9 @@ def main():
    receive_payment(sdk, prepare_response)
 
    # send payment
-   send_payment(sdk)
+   prepare_response = prepare_send_payment_lightning(sdk)
+   prepare_send_payment_liquid(sdk)
+   send_payment(sdk, prepare_response)
 
    # webhook
    register_webhook(sdk)

--- a/snippets/python/src/receive_payment.py
+++ b/snippets/python/src/receive_payment.py
@@ -16,6 +16,7 @@ def prepare_receive_lightning(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", receive_fees_sat, " sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -36,6 +37,7 @@ def prepare_receive_onchain(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", receive_fees_sat, " sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -53,6 +55,7 @@ def prepare_receive_liquid(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", receive_fees_sat, " sats")
         return prepare_response
     except Exception as error:
         logging.error(error)

--- a/snippets/python/src/send_payment.py
+++ b/snippets/python/src/send_payment.py
@@ -1,18 +1,41 @@
 import logging
-from breez_sdk_liquid import BindingLiquidSdk, PrepareSendRequest, SendPaymentRequest
+from breez_sdk_liquid import BindingLiquidSdk, PrepareSendRequest, SendPaymentRequest, PrepareSendResponse
 
 
-def send_payment(sdk: BindingLiquidSdk):
-    # ANCHOR: send-payment
-    # Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
-    destination = "Invoice, Liquid BIP21 or address"
+def prepare_send_payment_lightning(sdk: BindingLiquidSdk):
+    # ANCHOR: prepare-send-payment-lightning
+    # Set the bolt11 invoice you wish to pay
+    destination = "<bolt11 invoice>"
+    try:
+        prepare_response = sdk.prepare_send_payment(PrepareSendRequest(destination))
+
+        # If the fees are acceptable, continue to create the Send Payment
+        send_fees_sat = prepare_response.fees_sat
+        return prepare_response
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: prepare-send-payment-lightning
+
+def prepare_send_payment_liquid(sdk: BindingLiquidSdk):
+    # ANCHOR: prepare-send-payment-liquid
+    # Set the Liquid BIP21 or Liquid address you wish to pay
+    destination = "<Liquid BIP21 or address>"
     try:
         optional_amount_sat = 5_000
         prepare_response = sdk.prepare_send_payment(PrepareSendRequest(destination, optional_amount_sat))
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
+        return prepare_response
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: prepare-send-payment-liquid
 
+def send_payment(sdk: BindingLiquidSdk, prepare_response: PrepareSendResponse):
+    # ANCHOR: send-payment
+    try:
         send_response = sdk.send_payment(SendPaymentRequest(prepare_response))
         payment = send_response.payment
     except Exception as error:

--- a/snippets/python/src/send_payment.py
+++ b/snippets/python/src/send_payment.py
@@ -11,6 +11,7 @@ def prepare_send_payment_lightning(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", send_fees_sat, " sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -27,6 +28,7 @@ def prepare_send_payment_liquid(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", send_fees_sat, " sats")
         return prepare_response
     except Exception as error:
         logging.error(error)

--- a/snippets/react-native/receive_payment.ts
+++ b/snippets/react-native/receive_payment.ts
@@ -24,9 +24,8 @@ const examplePrepareLightningPayment = async () => {
 
   // If the fees are acceptable, continue to create the Receive Payment
   const receiveFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${receiveFeesSat} sats`)
   // ANCHOR_END: prepare-receive-payment-lightning
-
-  console.log(receiveFeesSat)
 }
 
 const examplePrepareOnchainPayment = async () => {
@@ -44,9 +43,8 @@ const examplePrepareOnchainPayment = async () => {
 
   // If the fees are acceptable, continue to create the Receive Payment
   const receiveFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${receiveFeesSat} sats`)
   // ANCHOR_END: prepare-receive-payment-onchain
-
-  console.log(receiveFeesSat)
 }
 
 const examplePrepareLiquidPayment = async () => {
@@ -61,9 +59,8 @@ const examplePrepareLiquidPayment = async () => {
 
   // If the fees are acceptable, continue to create the Receive Payment
   const receiveFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${receiveFeesSat} sats`)
   // ANCHOR_END: prepare-receive-payment-liquid
-
-  console.log(receiveFeesSat)
 }
 
 const exampleReceivePayment = async (prepareResponse: PrepareReceiveResponse) => {
@@ -76,6 +73,5 @@ const exampleReceivePayment = async (prepareResponse: PrepareReceiveResponse) =>
 
   const destination = res.destination
   // ANCHOR_END: receive-payment
-
   console.log(destination)
 }

--- a/snippets/react-native/send_payment.ts
+++ b/snippets/react-native/send_payment.ts
@@ -1,7 +1,7 @@
 import {
   prepareSendPayment,
   sendPayment,
-  PrepareSendResponse
+  type PrepareSendResponse
 } from '@breeztech/react-native-breez-sdk-liquid'
 
 const examplePrepareSendPaymentLightning = async () => {
@@ -12,7 +12,8 @@ const examplePrepareSendPaymentLightning = async () => {
   })
 
   // If the fees are acceptable, continue to create the Send Payment
-  const receiveFeesSat = prepareResponse.feesSat
+  const sendFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${sendFeesSat} sats`)
   // ANCHOR_END: prepare-send-payment-lightning
 }
 
@@ -26,7 +27,8 @@ const examplePrepareSendPaymentLiquid = async () => {
   })
 
   // If the fees are acceptable, continue to create the Send Payment
-  const receiveFeesSat = prepareResponse.feesSat
+  const sendFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${sendFeesSat} sats`)
   // ANCHOR_END: prepare-send-payment-liquid
 }
 
@@ -37,4 +39,5 @@ const exampleSendPayment = async (prepareResponse: PrepareSendResponse) => {
   })
   const payment = sendResponse.payment
   // ANCHOR_END: send-payment
+  console.log(payment)
 }

--- a/snippets/react-native/send_payment.ts
+++ b/snippets/react-native/send_payment.ts
@@ -1,20 +1,37 @@
 import {
   prepareSendPayment,
-  sendPayment
+  sendPayment,
+  PrepareSendResponse
 } from '@breeztech/react-native-breez-sdk-liquid'
 
-const exampleSendLightningPayment = async () => {
-  // ANCHOR: send-payment
-  // Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
+const examplePrepareSendPaymentLightning = async () => {
+  // ANCHOR: prepare-send-payment-lightning
+  // Set the bolt11 invoice you wish to pay
+  const prepareResponse = await prepareSendPayment({
+    destination: '<bolt11 invoice>'
+  })
+
+  // If the fees are acceptable, continue to create the Send Payment
+  const receiveFeesSat = prepareResponse.feesSat
+  // ANCHOR_END: prepare-send-payment-lightning
+}
+
+const examplePrepareSendPaymentLiquid = async () => {
+  // ANCHOR: prepare-send-payment-liquid
+  // Set the Liquid BIP21 or Liquid address you wish to pay
   const optionalAmountSat = 5_000
   const prepareResponse = await prepareSendPayment({
-    destination: 'Invoice, liquid address or BIP21 URI',
+    destination: '<Liquid BIP21 or address>',
     amountSat: optionalAmountSat
   })
 
   // If the fees are acceptable, continue to create the Send Payment
   const receiveFeesSat = prepareResponse.feesSat
+  // ANCHOR_END: prepare-send-payment-liquid
+}
 
+const exampleSendPayment = async (prepareResponse: PrepareSendResponse) => {
+  // ANCHOR: send-payment
   const sendResponse = await sendPayment({
     prepareResponse
   })

--- a/snippets/rust/src/receive_payment.rs
+++ b/snippets/rust/src/receive_payment.rs
@@ -21,9 +21,8 @@ async fn prepare_receive_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Receive Payment
     let receive_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", receive_fees_sat);
     // ANCHOR_END: prepare-receive-payment-lightning
-
-    dbg!(receive_fees_sat);
     Ok(())
 }
 
@@ -44,9 +43,8 @@ async fn prepare_receive_onchain(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Receive Payment
     let receive_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", receive_fees_sat);
     // ANCHOR_END: prepare-receive-payment-onchain
-
-    dbg!(receive_fees_sat);
     Ok(())
 }
 
@@ -63,9 +61,8 @@ async fn prepare_receive_liquid(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Receive Payment
     let receive_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", receive_fees_sat);
     // ANCHOR_END: prepare-receive-payment-liquid
-
-    dbg!(receive_fees_sat);
     Ok(())
 }
 
@@ -85,7 +82,6 @@ async fn receive_payment(
 
     let destination = res.destination;
     // ANCHOR_END: receive-payment
-
     dbg!(destination);
     Ok(())
 }

--- a/snippets/rust/src/send_payment.rs
+++ b/snippets/rust/src/send_payment.rs
@@ -3,25 +3,48 @@ use std::sync::Arc;
 use anyhow::Result;
 use breez_sdk_liquid::prelude::*;
 
-async fn send_payment(sdk: Arc<LiquidSdk>) -> Result<()> {
-    // ANCHOR: send-payment
-    // Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
+async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
+    // ANCHOR: prepare-send-payment-lightning
+    // Set the bolt11 invoice you wish to pay
+    let prepare_response = sdk
+        .prepare_send_payment(&PrepareSendRequest {
+            destination: "<bolt11 invoice>".to_string(),
+            amount_sat: None,
+        })
+        .await?;
+
+    // If the fees are acceptable, continue to create the Send Payment
+    let send_fees_sat = prepare_response.fees_sat;
+    // ANCHOR_END: prepare-send-payment-lightning
+    dbg!(send_fees_sat);
+    Ok(())
+}
+
+async fn prepare_send_payment_liquid(sdk: Arc<LiquidSdk>) -> Result<()> {
+    // ANCHOR: prepare-send-payment-liquid
+    // Set the Liquid BIP21 or Liquid address you wish to pay
     let optional_amount_sat = Some(5_000);
     let prepare_response = sdk
         .prepare_send_payment(&PrepareSendRequest {
-            destination: "Invoice, Liquid BIP21 or address".to_string(),
+            destination: "<Liquid BIP21 or address>".to_string(),
             amount_sat: optional_amount_sat,
         })
         .await?;
 
     // If the fees are acceptable, continue to create the Send Payment
-    let _send_fees_sat = prepare_response.fees_sat;
+    let send_fees_sat = prepare_response.fees_sat;
+    // ANCHOR_END: prepare-send-payment-liquid
+    dbg!(send_fees_sat);
+    Ok(())
+}
 
+async fn send_payment(sdk: Arc<LiquidSdk>, prepare_response: PrepareSendResponse) -> Result<()> {
+    // ANCHOR: send-payment
     let send_response = sdk
         .send_payment(&SendPaymentRequest { prepare_response })
         .await?;
     let payment = send_response.payment;
     // ANCHOR_END: send-payment
-
+    dbg!(payment);
     Ok(())
 }

--- a/snippets/rust/src/send_payment.rs
+++ b/snippets/rust/src/send_payment.rs
@@ -2,6 +2,7 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use breez_sdk_liquid::prelude::*;
+use log::info;
 
 async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
     // ANCHOR: prepare-send-payment-lightning
@@ -15,8 +16,8 @@ async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Send Payment
     let send_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", send_fees_sat);
     // ANCHOR_END: prepare-send-payment-lightning
-    dbg!(send_fees_sat);
     Ok(())
 }
 
@@ -33,8 +34,8 @@ async fn prepare_send_payment_liquid(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     // If the fees are acceptable, continue to create the Send Payment
     let send_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", send_fees_sat);
     // ANCHOR_END: prepare-send-payment-liquid
-    dbg!(send_fees_sat);
     Ok(())
 }
 

--- a/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
@@ -1,21 +1,41 @@
 import BreezSDKLiquid
 
-func sendPayment(sdk: BindingLiquidSdk) -> SendPaymentResponse? {
-    // ANCHOR: send-payment
-    // Set the Lightning invoice, Liquid BIP21 or Liquid address you wish to pay
+func prepareSendPaymentLightning(sdk: BindingLiquidSdk) -> PrepareSendResponse? {
+    // ANCHOR: prepare-send-payment-lightning
+    // Set the bolt11 invoice you wish to pay
+    let prepareResponse = try? sdk
+        .prepareSendPayment(req: PrepareSendRequest (
+            destination: "<bolt11 invoice>"
+        ))
+
+    // If the fees are acceptable, continue to create the Send Payment
+    let sendFeesSat = prepareResponse!.feesSat
+    print(sendFeesSat)
+    // ANCHOR_END: prepare-send-payment-lightning
+    return prepareResponse
+}
+
+func prepareSendPaymentLiquid(sdk: BindingLiquidSdk) -> PrepareSendResponse? {
+    // ANCHOR: prepare-send-payment-liquid
+    // Set the Liquid BIP21 or Liquid address you wish to pay
     let optionalAmountSat: UInt64? = Optional.some(5000)
     let prepareResponse = try? sdk
         .prepareSendPayment(req: PrepareSendRequest (
-            destination: "Invoice, Liquid BIP21 or address",
+            destination: "<Liquid BIP21 or address>",
             amountSat: optionalAmountSat
         ))
 
     // If the fees are acceptable, continue to create the Send Payment
     let sendFeesSat = prepareResponse!.feesSat
     print(sendFeesSat)
+    // ANCHOR_END: prepare-send-payment-liquid
+    return prepareResponse
+}
 
+func sendPayment(sdk: BindingLiquidSdk, prepareResponse: PrepareSendResponse) -> SendPaymentResponse? {
+    // ANCHOR: send-payment
     let sendResponse = try? sdk.sendPayment(req: SendPaymentRequest (
-        prepareResponse: prepareResponse!
+        prepareResponse: prepareResponse
     ))
     let payment = sendResponse!.payment
     print(payment)

--- a/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
@@ -10,7 +10,7 @@ func prepareSendPaymentLightning(sdk: BindingLiquidSdk) -> PrepareSendResponse? 
 
     // If the fees are acceptable, continue to create the Send Payment
     let sendFeesSat = prepareResponse!.feesSat
-    print(sendFeesSat)
+    print("Fees: {} sats", sendFeesSat);
     // ANCHOR_END: prepare-send-payment-lightning
     return prepareResponse
 }
@@ -27,7 +27,7 @@ func prepareSendPaymentLiquid(sdk: BindingLiquidSdk) -> PrepareSendResponse? {
 
     // If the fees are acceptable, continue to create the Send Payment
     let sendFeesSat = prepareResponse!.feesSat
-    print(sendFeesSat)
+    print("Fees: {} sats", sendFeesSat);
     // ANCHOR_END: prepare-send-payment-liquid
     return prepareResponse
 }
@@ -38,7 +38,7 @@ func sendPayment(sdk: BindingLiquidSdk, prepareResponse: PrepareSendResponse) ->
         prepareResponse: prepareResponse
     ))
     let payment = sendResponse!.payment
-    print(payment)
     // ANCHOR_END: send-payment
+    print(payment)
     return sendResponse
 }

--- a/src/guide/pay_onchain.md
+++ b/src/guide/pay_onchain.md
@@ -2,6 +2,11 @@
 
 You can send funds from the Breez SDK wallet to an on-chain address as follows.
 
+<div class="warning">
+<h4>Developer note</h4>
+Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
+</div>
+
 ## Checking the limits
 First, fetch the current Send Onchain limits:
 
@@ -289,8 +294,3 @@ Note that one of the arguments will be the result from the `prepare` call above.
 ```
 </section>
 </custom-tabs>
-
-<div class="warning">
-<h4>Developer note</h4>
-Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
-</div>

--- a/src/guide/receive_payment.md
+++ b/src/guide/receive_payment.md
@@ -6,6 +6,11 @@ Once the SDK is initialized, you can directly begin receiving payments. The rece
 1. [Preparing the Payment](receive_payment.md#preparing-payments)
 1. [Receiving the Payment](receive_payment.md#receiving-payments-1)
 
+<div class="warning">
+<h4>Developer note</h4>
+Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
+</div>
+
 ## Preparing Payments
 During the prepare step, the SDK ensures that the inputs are valid with respect to the specified payment method,
 and also returns the relative fees related to the payment so they can be confirmed.
@@ -311,7 +316,3 @@ receive method, optionally specifying a description.
 ```
 </section>
 </custom-tabs>
-<div class="warning">
-<h4>Developer note</h4>
-Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
-</div>

--- a/src/guide/send_payment.md
+++ b/src/guide/send_payment.md
@@ -1,16 +1,173 @@
-# Sending Lightning/Liquid Payments
+# Sending Payments
 
-Once the SDK is set up, you can start sending payments too.
+Once the SDK is initialized, you can directly begin sending payments. The send process takes two steps:
+1. [Preparing the Payment](send_payment.md#preparing-payments)
+1. [Sending the Payment](send_payment.md#sending-payments-1)
 
+<div class="warning">
+<h4>Developer note</h4>
+Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
+</div>
 
-The `destination` field of the payment request now supports Liquid BIP21, Liquid addresses and Lightning invoices. For onchain (Bitcoin) payments, see [Sending an on-chain transaction](pay_onchain.md).
+## Preparing Payments 
+During the prepare step, the SDK ensures that the inputs are valid with respect to the destination,
+and also returns the relative fees related to the payment so they can be confirmed. 
 
-## Amount validation
+The `destination` field of the payment request supports Liquid BIP21, Liquid addresses and Lightning invoices
 
-There are cases in which both the destination and the user provide an amount to be paid. Here are the possible scenarios and their outcomes:
-- **Liquid BIP21 URI amount and request amount field are set** - the SDK will make sure the two values match, else an error will be thrown.
-- **Invoice amount and request amount field are set** - the SDK will make sure the two values match, else an error will be thrown.
-- **Liquid address is used** - the SDK will make sure the request amount is set. Else, the "Amount Missing" error will be thrown.
+### Lightning
+When sending via Lightning, the bolt11 invoice amount **must** be set. If the optional prepare request amount is also set, the SDK will make sure the two values match, else an error will be thrown. 
+
+The SDK will also validate that the amount is within the send lightning limits of the swap service.
+
+**Note:** The payment may fallback to a direct Liquid payment (if the payer's client supports this).
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/send_payment.rs:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/SendPayment.swift:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/send_payment.ts:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/send_payment.dart:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/send_payment.py:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/send_payment.go:prepare-send-payment-lightning}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/SendPayment.cs:prepare-send-payment-lightning}}
+```
+</section>
+</custom-tabs>
+
+### Bitcoin
+
+For onchain (Bitcoin) payments, see [Sending an on-chain transaction](pay_onchain.md).
+
+### Liquid
+When sending via Liquid, a BIP21 URI or Liquid address can be used as the destination. 
+
+If a Liquid address is used, the optional prepare request amount **must** be set. 
+
+If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request amount **must** be set. When both amounts are set, the SDK will make sure the two values match, else an error will be thrown.
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/send_payment.rs:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/SendPayment.swift:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/send_payment.ts:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/send_payment.dart:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/send_payment.py:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/send_payment.go:prepare-send-payment-liquid}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/SendPayment.cs:prepare-send-payment-liquid}}
+```
+</section>
+</custom-tabs>
+
+## Sending Payments
+Once the payment has been prepared, all you have to do is pass the prepare response as an argument to the
+send method.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -77,7 +234,3 @@ There are cases in which both the destination and the user provide an amount to 
 ```
 </section>
 </custom-tabs>
-<div class="warning">
-<h4>Developer note</h4>
-Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
-</div>

--- a/src/guide/send_payment.md
+++ b/src/guide/send_payment.md
@@ -97,7 +97,7 @@ When sending via Liquid, a BIP21 URI or Liquid address can be used as the destin
 
 If a Liquid address is used, the optional prepare request amount **must** be set. 
 
-If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request amount **must** be set. When both amounts are set, the SDK will make sure the two values match, else an error will be thrown.
+If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request amount **must** be set. When both amounts are set, the SDK will prioritize the **request amount** over the BIP21 amount.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>


### PR DESCRIPTION
This PR expands the Sending Payments page to:
- be more consistent with the Receiving Payments page
- include a statement that the SDK validates the Lightning bolt11 amount is within the swap sending limits.