### PR TITLE
Add docs for Liquid drain and list payments details

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
     inputs:
       sdk-ref:
-        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc4'
+        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc8'
         required: false
         type: string
-        default: 0.5.0-rc4
+        default: 0.5.0-rc8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Used only for Rust snippets
-      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc4' }}
+      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc8' }}
       # Used for RN and Flutter snippets
-      package-version: '0.5.0-rc4'
+      package-version: '0.5.0-rc8'
     steps:
       - run: echo "set pre-setup output variables"
 
@@ -281,7 +281,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "16.1-beta"
+        xcode-version: "latest-stable"
           
     - name: Build
       working-directory: snippets/swift/BreezSDKExamples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
     inputs:
       sdk-ref:
-        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc1'
+        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc4'
         required: false
         type: string
-        default: 0.5.0-rc1
+        default: 0.5.0-rc4
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Used only for Rust snippets
-      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc1' }}
+      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc4' }}
       # Used for RN and Flutter snippets
-      package-version: '0.5.0-rc1'
+      package-version: '0.5.0-rc4'
     steps:
       - run: echo "set pre-setup output variables"
 

--- a/examples/python/cli/pyproject.toml
+++ b/examples/python/cli/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-breez-sdk-liquid = "0.5.0-rc1"
+breez-sdk-liquid = "0.5.0-rc4"
 argparse = "^1.4.0"
 qrcode = "^7.4.2"
 colorama = "^0.4.6"

--- a/examples/python/cli/pyproject.toml
+++ b/examples/python/cli/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-breez-sdk-liquid = "0.5.0-rc4"
+breez-sdk-liquid = "0.5.0-rc8"
 argparse = "^1.4.0"
 qrcode = "^7.4.2"
 colorama = "^0.4.6"

--- a/snippets/csharp/ListPayments.cs
+++ b/snippets/csharp/ListPayments.cs
@@ -53,4 +53,40 @@ public class ListPaymentsSnippets
         }
         // ANCHOR_END: list-payments-filtered
     }
+
+    public void ListPaymentsDetailsAddress(BindingLiquidSdk sdk)
+    {
+        // ANCHOR: list-payments-details-address
+        try
+        {
+            var address = "<Bitcoin address>";
+            var payments = sdk.ListPayments(
+                new ListPaymentsRequest(
+                    details: new ListPaymentDetails.Bitcoin(address)
+                ));
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: list-payments-details-address
+    }
+
+    public void ListPaymentsDetailsDestination(BindingLiquidSdk sdk)
+    {
+        // ANCHOR: list-payments-details-destination
+        try
+        {
+            var destination = "<Liquid BIP21 or address>";
+            var payments = sdk.ListPayments(
+                new ListPaymentsRequest(
+                    details: new ListPaymentDetails.Liquid(destination)
+                ));
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: list-payments-details-destination
+    }
 }

--- a/snippets/csharp/PayOnchain.cs
+++ b/snippets/csharp/PayOnchain.cs
@@ -23,7 +23,7 @@ public class SendOnchainSnippets
         // ANCHOR: prepare-pay-onchain
         try
         {
-            var amount = new PayOnchainAmount.Receiver(5000);
+            var amount = new PayAmount.Receiver(5000);
             var prepareRequest = new PreparePayOnchainRequest(amount);
             var prepareResponse = sdk.PreparePayOnchain(prepareRequest);
 
@@ -42,7 +42,7 @@ public class SendOnchainSnippets
         // ANCHOR: prepare-pay-onchain-drain
         try
         {
-            var amount = new PayOnchainAmount.Drain();
+            var amount = new PayAmount.Drain();
             var prepareRequest = new PreparePayOnchainRequest(amount);
             var prepareResponse = sdk.PreparePayOnchain(prepareRequest);
 
@@ -61,7 +61,7 @@ public class SendOnchainSnippets
         // ANCHOR: prepare-pay-onchain-fee-rate
         try
         {
-            var amount = new PayOnchainAmount.Receiver(5000);
+            var amount = new PayAmount.Receiver(5000);
             uint optionalSatPerVbyte = 21;
 
             var prepareRequest = new PreparePayOnchainRequest(amount, optionalSatPerVbyte);

--- a/snippets/csharp/SendPayment.cs
+++ b/snippets/csharp/SendPayment.cs
@@ -29,8 +29,8 @@ public class SendPaymentSnippets
         var destination = "<Liquid BIP21 or address>";
         try
         {
-            ulong optionalAmountSat = 5000;
-            var prepareResponse = sdk.PrepareSendPayment(new PrepareSendRequest(destination, optionalAmountSat));
+            var optionalAmount = new PayAmount.Receiver(5000);
+            var prepareResponse = sdk.PrepareSendPayment(new PrepareSendRequest(destination, optionalAmount));
 
             // If the fees are acceptable, continue to create the Send Payment
             var sendFeesSat = prepareResponse.feesSat;
@@ -41,6 +41,27 @@ public class SendPaymentSnippets
             // Handle error
         }
         // ANCHOR_END: prepare-send-payment-liquid
+    }
+
+    public void PrepareSendPaymentLiquidDrain(BindingLiquidSdk sdk)
+    {
+        // ANCHOR: prepare-send-payment-liquid-drain
+        // Set the Liquid BIP21 or address you wish to pay
+        var destination = "<Liquid BIP21 or address>";
+        try
+        {
+            var optionalAmount = new PayAmount.Drain();
+            var prepareResponse = sdk.PrepareSendPayment(new PrepareSendRequest(destination, optionalAmount));
+
+            // If the fees are acceptable, continue to create the Send Payment
+            var sendFeesSat = prepareResponse.feesSat;
+            Console.WriteLine($"Fees: {sendFeesSat} sats");
+        }
+        catch (Exception)
+        {
+            // Handle error
+        }
+        // ANCHOR_END: prepare-send-payment-liquid-drain
     }
 
     public void SendPayment(BindingLiquidSdk sdk, PrepareSendResponse prepareResponse)

--- a/snippets/dart_snippets/lib/list_payments.dart
+++ b/snippets/dart_snippets/lib/list_payments.dart
@@ -31,3 +31,25 @@ Future<List<Payment>> listPaymentsFiltered() async {
   // ANCHOR_END: list-payments-filtered
   return paymentsList;
 }
+
+Future<List<Payment>> listPaymentsDetailsAddress() async {
+  // ANCHOR: list-payments-details-address
+  String address = "<Bitcoin address>";
+  ListPaymentsRequest req = ListPaymentsRequest(
+    details: ListPaymentDetails_Bitcoin(address: address),
+  );
+  List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
+  // ANCHOR_END: list-payments-details-address
+  return paymentsList;
+}
+
+Future<List<Payment>> listPaymentsDetailsDestination() async {
+  // ANCHOR: list-payments-details-destination
+  String destination = "<Liquid BIP21 or address>";
+  ListPaymentsRequest req = ListPaymentsRequest(
+    details: ListPaymentDetails_Liquid(destination: destination),
+  );
+  List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
+  // ANCHOR_END: list-payments-details-destination
+  return paymentsList;
+}

--- a/snippets/dart_snippets/lib/pay_onchain.dart
+++ b/snippets/dart_snippets/lib/pay_onchain.dart
@@ -13,7 +13,7 @@ Future<OnchainPaymentLimitsResponse> getCurrentLimits() async {
 Future<PreparePayOnchainResponse> preparePayOnchain() async {
   // ANCHOR: prepare-pay-onchain
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
-    amount: PayOnchainAmount_Receiver(amountSat: 5000 as BigInt),
+    amount: PayAmount_Receiver(amountSat: 5000 as BigInt),
   );
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(
     req: preparePayOnchainRequest,
@@ -29,7 +29,7 @@ Future<PreparePayOnchainResponse> preparePayOnchain() async {
 Future<PreparePayOnchainResponse> preparePayOnchainDrain() async {
   // ANCHOR: prepare-pay-onchain-drain
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
-    amount: PayOnchainAmount_Drain(),
+    amount: PayAmount_Drain(),
   );
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(
     req: preparePayOnchainRequest,
@@ -47,7 +47,7 @@ Future<PreparePayOnchainResponse> preparePayOnchainFeeRate() async {
   int optionalSatPerVbyte = 21;
 
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
-    amount: PayOnchainAmount_Receiver(amountSat: 5000 as BigInt),
+    amount: PayAmount_Receiver(amountSat: 5000 as BigInt),
     feeRateSatPerVbyte: optionalSatPerVbyte,
   );
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -18,7 +18,7 @@ Future<PrepareSendResponse> prepareSendPaymentLightning() async {
 Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
   // ANCHOR: prepare-send-payment-liquid
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmount = PayAmount_Receiver(amountSat: 5000 as BigInt);
+  PayAmount_Receiver optionalAmount = PayAmount_Receiver(amountSat: 5000 as BigInt);
   PrepareSendRequest prepareSendRequest = PrepareSendRequest(
     destination: "<Liquid BIP21 or address>",
     amount: optionalAmount,
@@ -38,7 +38,7 @@ Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
 Future<PrepareSendResponse> prepareSendPaymentLiquidDrain() async {
   // ANCHOR: prepare-send-payment-liquid-drain
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmount = PayAmount_Drain(),
+  PayAmount_Drain optionalAmount = PayAmount_Drain();
   PrepareSendRequest prepareSendRequest = PrepareSendRequest(
     destination: "<Liquid BIP21 or address>",
     amount: optionalAmount,

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -18,16 +18,40 @@ Future<PrepareSendResponse> prepareSendPaymentLightning() async {
 Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
   // ANCHOR: prepare-send-payment-liquid
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmountSat = BigInt.from(5000);
+  BigInt optionalAmount = PayAmount_Receiver(amountSat: 5000 as BigInt);
+  PrepareSendRequest prepareSendRequest = PrepareSendRequest(
+    destination: "<Liquid BIP21 or address>",
+    amount: optionalAmount,
+  );
 
   PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
-    req: PrepareSendRequest(destination: "<Liquid BIP21 or address>", amountSat: optionalAmountSat),
+    req: prepareSendRequest,
   );
 
   // If the fees are acceptable, continue to create the Send Payment
   BigInt sendFeesSat = prepareSendResponse.feesSat;
   print("Fees: $sendFeesSat sats");
   // ANCHOR_END: prepare-send-payment-liquid
+  return prepareSendResponse;
+}
+
+Future<PrepareSendResponse> prepareSendPaymentLiquidDrain() async {
+  // ANCHOR: prepare-send-payment-liquid-drain
+  // Set the Liquid BIP21 or Liquid address you wish to pay
+  BigInt optionalAmount = PayAmount_Drain(),
+  PrepareSendRequest prepareSendRequest = PrepareSendRequest(
+    destination: "<Liquid BIP21 or address>",
+    amount: optionalAmount,
+  );
+
+  PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
+    req: prepareSendRequest,
+  );
+
+  // If the fees are acceptable, continue to create the Send Payment
+  BigInt sendFeesSat = prepareSendResponse.feesSat;
+  print("Fees: $sendFeesSat sats");
+  // ANCHOR_END: prepare-send-payment-liquid-drain
   return prepareSendResponse;
 }
 

--- a/snippets/dart_snippets/pubspec.lock
+++ b/snippets/dart_snippets/pubspec.lock
@@ -46,10 +46,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: fb8cb1082d80ba3219a03e2af40857ce2348f8d0
+      resolved-ref: d13880259533974e9551bc143bbae825f198a44d
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.5.0-rc1"
+    version: "0.5.0-rc4"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -140,10 +140,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: b63b3061ffdf1df2af95f0393c169262d66a2236
+      resolved-ref: a40fbf0a36e4fd3f07235ca6976f3ba09563015e
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.5.0-rc1"
+    version: "0.5.0-rc4"
   flutter_rust_bridge:
     dependency: transitive
     description:

--- a/snippets/dart_snippets/pubspec.lock
+++ b/snippets/dart_snippets/pubspec.lock
@@ -46,10 +46,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: d13880259533974e9551bc143bbae825f198a44d
+      resolved-ref: 619a9b23256820b291ddf97f3fee7224c5b084fd
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.5.0-rc4"
+    version: "0.5.0-rc8"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -140,10 +140,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: a40fbf0a36e4fd3f07235ca6976f3ba09563015e
+      resolved-ref: a0ee25c652159a0c99faaf55f8b21becc5b32999
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.5.0-rc4"
+    version: "0.5.0-rc8"
   flutter_rust_bridge:
     dependency: transitive
     description:

--- a/snippets/dart_snippets/pubspec.yaml
+++ b/snippets/dart_snippets/pubspec.yaml
@@ -10,11 +10,11 @@ dependencies:
   breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-dart
-      tag: 0.5.0-rc1
+      tag: 0.5.0-rc4
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
-      tag: 0.5.0-rc1
+      tag: 0.5.0-rc4
   rxdart: ^0.28.0  
 
 dependency_overrides:

--- a/snippets/dart_snippets/pubspec.yaml
+++ b/snippets/dart_snippets/pubspec.yaml
@@ -10,11 +10,11 @@ dependencies:
   breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-dart
-      tag: 0.5.0-rc4
+      tag: 0.5.0-rc8
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
-      tag: 0.5.0-rc4
+      tag: 0.5.0-rc8
   rxdart: ^0.28.0  
 
 dependency_overrides:

--- a/snippets/go/go.mod
+++ b/snippets/go/go.mod
@@ -2,6 +2,6 @@ module main
 
 go 1.19
 
-require github.com/breez/breez-sdk-liquid-go v0.5.0-rc4
+require github.com/breez/breez-sdk-liquid-go v0.5.0-rc8
 
 //replace github.com/breez/breez-sdk-liquid-go => ./packages/breez-sdk-liquid-go

--- a/snippets/go/go.mod
+++ b/snippets/go/go.mod
@@ -2,6 +2,6 @@ module main
 
 go 1.19
 
-require github.com/breez/breez-sdk-liquid-go v0.5.0-rc1
+require github.com/breez/breez-sdk-liquid-go v0.5.0-rc4
 
 //replace github.com/breez/breez-sdk-liquid-go => ./packages/breez-sdk-liquid-go

--- a/snippets/go/list_payments.go
+++ b/snippets/go/list_payments.go
@@ -45,3 +45,29 @@ func ListPaymentsFiltered(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	}
 	// ANCHOR_END: list-payments-filtered
 }
+
+func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
+	// ANCHOR: list-payments-details-address
+	address := "<Bitcoin address>"
+	details := breez_sdk_liquid.ListPaymentDetailsBitcoin{Address: address}
+	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
+		Details: &details,
+	}
+	if payments, err := sdk.ListPayments(listPaymentsRequest); err == nil {
+		log.Printf("%#v", payments)
+	}
+	// ANCHOR_END: list-payments-details-address
+}
+
+func ListPaymentsDetailsDestination(sdk *breez_sdk_liquid.BindingLiquidSdk) {
+	// ANCHOR: list-payments-details-destination
+	destination := "<Liquid BIP21 or address>"
+	details := breez_sdk_liquid.ListPaymentDetailsLiquid{Destination: destination}
+	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
+		Details: &details,
+	}
+	if payments, err := sdk.ListPayments(listPaymentsRequest); err == nil {
+		log.Printf("%#v", payments)
+	}
+	// ANCHOR_END: list-payments-details-destination
+}

--- a/snippets/go/list_payments.go
+++ b/snippets/go/list_payments.go
@@ -49,7 +49,9 @@ func ListPaymentsFiltered(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-address
 	address := "<Bitcoin address>"
-	details := breez_sdk_liquid.ListPaymentDetailsBitcoin{Address: address}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsBitcoin{
+		Address: address,
+	}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}
@@ -62,7 +64,9 @@ func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsDestination(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-destination
 	destination := "<Liquid BIP21 or address>"
-	details := breez_sdk_liquid.ListPaymentDetailsLiquid{Destination: destination}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsLiquid{
+		Destination: destination,
+	}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}

--- a/snippets/go/pay_onchain.go
+++ b/snippets/go/pay_onchain.go
@@ -17,7 +17,7 @@ func GetCurrentRevSwapLimits(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 
 func PreparePayOnchain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-pay-onchain
-	amount := breez_sdk_liquid.PayOnchainAmountReceiver{AmountSat: 5_000}
+	amount := breez_sdk_liquid.PayAmountReceiver{AmountSat: 5_000}
 	prepareRequest := breez_sdk_liquid.PreparePayOnchainRequest{
 		Amount: amount,
 	}
@@ -32,7 +32,7 @@ func PreparePayOnchain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 
 func PreparePayOnchainDrain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-pay-onchain-drain
-	amount := breez_sdk_liquid.PayOnchainAmountDrain{}
+	amount := breez_sdk_liquid.PayAmountDrain{}
 	prepareRequest := breez_sdk_liquid.PreparePayOnchainRequest{
 		Amount: amount,
 	}
@@ -47,7 +47,7 @@ func PreparePayOnchainDrain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 
 func PreparePayOnchainFeeRate(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-pay-onchain-fee-rate
-	amount := breez_sdk_liquid.PayOnchainAmountReceiver{AmountSat: 5_000}
+	amount := breez_sdk_liquid.PayAmountReceiver{AmountSat: 5_000}
 	optionalSatPerVbyte := uint32(21)
 	prepareRequest := breez_sdk_liquid.PreparePayOnchainRequest{
 		Amount:             amount,

--- a/snippets/go/send_payment.go
+++ b/snippets/go/send_payment.go
@@ -28,10 +28,11 @@ func PrepareSendPaymentLiquid(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-send-payment-liquid
 	// Set the Liquid BIP21 or Liquid address you wish to pay
 	destination := "<Liquid BIP21 or address>"
-	optionalAmountSat := uint64(5_000)
+	optionalAmount := breez_sdk_liquid.PayAmountReceiver{AmountSat: uint64(5_000)}
+
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,
-		AmountSat:   &optionalAmountSat,
+		Amount:      &optionalAmount,
 	}
 	prepareResponse, err := sdk.PrepareSendPayment(prepareRequest)
 	if err != nil {
@@ -42,6 +43,27 @@ func PrepareSendPaymentLiquid(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	sendFeesSat := prepareResponse.FeesSat
 	log.Printf("Fees: %v sats", sendFeesSat)
 	// ANCHOR_END: prepare-send-payment-liquid
+}
+
+func PrepareSendPaymentLiquidDrain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
+	// ANCHOR: prepare-send-payment-liquid-drain
+	// Set the Liquid BIP21 or Liquid address you wish to pay
+	destination := "<Liquid BIP21 or address>"
+	optionalAmount := breez_sdk_liquid.PayAmountDrain{}
+
+	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
+		Destination: destination,
+		Amount:      &optionalAmount,
+	}
+	prepareResponse, err := sdk.PrepareSendPayment(prepareRequest)
+	if err != nil {
+		log.Printf("Error: %#v", err)
+		return
+	}
+
+	sendFeesSat := prepareResponse.FeesSat
+	log.Printf("Fees: %v sats", sendFeesSat)
+	// ANCHOR_END: prepare-send-payment-liquid-drain
 }
 
 func SendPayment(sdk *breez_sdk_liquid.BindingLiquidSdk, prepareResponse breez_sdk_liquid.PrepareSendResponse) {

--- a/snippets/go/send_payment.go
+++ b/snippets/go/send_payment.go
@@ -28,7 +28,7 @@ func PrepareSendPaymentLiquid(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-send-payment-liquid
 	// Set the Liquid BIP21 or Liquid address you wish to pay
 	destination := "<Liquid BIP21 or address>"
-	optionalAmount := breez_sdk_liquid.PayAmountReceiver{AmountSat: uint64(5_000)}
+	var optionalAmount breez_sdk_liquid.PayAmount = breez_sdk_liquid.PayAmountReceiver{AmountSat: uint64(5_000)}
 
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,
@@ -49,7 +49,7 @@ func PrepareSendPaymentLiquidDrain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-send-payment-liquid-drain
 	// Set the Liquid BIP21 or Liquid address you wish to pay
 	destination := "<Liquid BIP21 or address>"
-	optionalAmount := breez_sdk_liquid.PayAmountDrain{}
+	var optionalAmount breez_sdk_liquid.PayAmount = breez_sdk_liquid.PayAmountDrain{}
 
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,

--- a/snippets/kotlin_mpp_lib/shared/build.gradle.kts
+++ b/snippets/kotlin_mpp_lib/shared/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc4")
+                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc8")
             }
         }
     }

--- a/snippets/kotlin_mpp_lib/shared/build.gradle.kts
+++ b/snippets/kotlin_mpp_lib/shared/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc1")
+                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc4")
             }
         }
     }

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ListPayments.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ListPayments.kt
@@ -39,4 +39,32 @@ class ListPayments {
         }
         // ANCHOR_END: list-payments-filtered
     }
+
+    fun listPaymentsDetailsAddress(sdk: BindingLiquidSdk) {
+        // ANCHOR: list-payments-details-address
+        try {
+            val address = "<Bitcoin address>"
+            val payments = sdk.listPayments(
+                ListPaymentsRequest(
+                    details = ListPaymentDetails.Bitcoin(address)
+                ))
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: list-payments-details-address
+    }
+
+    fun listPaymentsDetailsDestination(sdk: BindingLiquidSdk) {
+        // ANCHOR: list-payments-details-destination
+        try {
+            val destination = "<Liquid BIP21 or address>"
+            val payments = sdk.listPayments(
+                ListPaymentsRequest(
+                    details = ListPaymentDetails.Liquid(destination)
+                ))
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: list-payments-details-destination
+    }
 }

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/PayOnchain.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/PayOnchain.kt
@@ -17,7 +17,7 @@ class PayOnchain {
     fun preparePayOnchain(sdk: BindingLiquidSdk) {
         // ANCHOR: prepare-pay-onchain
         try {
-            val amount = PayOnchainAmount.Receiver(5_000.toULong())
+            val amount = PayAmount.Receiver(5_000.toULong())
             val prepareRequest = PreparePayOnchainRequest(amount)
             val prepareResponse = sdk.preparePayOnchain(prepareRequest)
 
@@ -32,7 +32,7 @@ class PayOnchain {
     fun preparePayOnchainDrain(sdk: BindingLiquidSdk) {
         // ANCHOR: prepare-pay-onchain-drain
         try {
-            val amount = PayOnchainAmount.Drain
+            val amount = PayAmount.Drain
             val prepareRequest = PreparePayOnchainRequest(amount)
             val prepareResponse = sdk.preparePayOnchain(prepareRequest)
 
@@ -47,7 +47,7 @@ class PayOnchain {
     fun preparePayOnchainFeeRate(sdk: BindingLiquidSdk) {
         // ANCHOR: prepare-pay-onchain-fee-rate
         try {
-            val amount = PayOnchainAmount.Receiver(5_000.toULong())
+            val amount = PayAmount.Receiver(5_000.toULong())
             val optionalSatPerVbyte = 21
 
             val prepareRequest = PreparePayOnchainRequest(amount, optionalSatPerVbyte.toUInt())

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt
@@ -24,8 +24,8 @@ class SendPayment {
         // Set the Liquid BIP21 or Liquid address you wish to pay
         val destination = "<Liquid BIP21 or address>"
         try {
-            val optionalAmountSat = 5_000.toULong();
-            val prepareResponse = sdk.prepareSendPayment(PrepareSendRequest(destination, optionalAmountSat))
+            val optionalAmount = PayAmount.Receiver(5_000.toULong())
+            val prepareResponse = sdk.prepareSendPayment(PrepareSendRequest(destination, optionalAmount))
 
             // If the fees are acceptable, continue to create the Send Payment
             val sendFeesSat = prepareResponse.feesSat;
@@ -34,6 +34,23 @@ class SendPayment {
             // handle error
         }
         // ANCHOR_END: prepare-send-payment-liquid
+    }
+
+    fun prepareSendPaymentLiquidDrain(sdk: BindingLiquidSdk) {
+        // ANCHOR: prepare-send-payment-liquid-drain
+        // Set the Liquid BIP21 or Liquid address you wish to pay
+        val destination = "<Liquid BIP21 or address>"
+        try {
+            val optionalAmount = PayAmount.Drain
+            val prepareResponse = sdk.prepareSendPayment(PrepareSendRequest(destination, optionalAmount))
+
+            // If the fees are acceptable, continue to create the Send Payment
+            val sendFeesSat = prepareResponse.feesSat;
+            // Log.v("Breez", "Fees: ${sendFeesSat} sats")
+        } catch (e: Exception) {
+            // handle error
+        }
+        // ANCHOR_END: prepare-send-payment-liquid-drain
     }
 
     fun sendPayment(sdk: BindingLiquidSdk, prepareResponse: PrepareSendResponse) {

--- a/snippets/python/src/list_payments.py
+++ b/snippets/python/src/list_payments.py
@@ -1,4 +1,4 @@
-from breez_sdk_liquid import BindingLiquidSdk, GetPaymentRequest, ListPaymentsRequest, PaymentType
+from breez_sdk_liquid import BindingLiquidSdk, GetPaymentRequest, ListPaymentDetails, ListPaymentsRequest, PaymentType
 import logging
 
 
@@ -32,6 +32,30 @@ def list_payments_filtered(sdk: BindingLiquidSdk):
             limit = 50)
         sdk.list_payments(req)
         # ANCHOR_END: list-payments-filtered
+    except Exception as error:
+        logging.error(error)
+        raise
+
+def list_payments_details_address(sdk: BindingLiquidSdk):
+    try:
+        # ANCHOR: list-payments-details-address
+        address = "<Bitcoin address>"
+        req = ListPaymentsRequest(
+            details = ListPaymentDetails.BITCOIN(address))
+        sdk.list_payments(req)
+        # ANCHOR_END: list-payments-details-address
+    except Exception as error:
+        logging.error(error)
+        raise
+
+def list_payments_details_destination(sdk: BindingLiquidSdk):
+    try:
+        # ANCHOR: list-payments-details-destination
+        destination = "<Liquid BIP21 or address>"
+        req = ListPaymentsRequest(
+            details = ListPaymentDetails.LIQUID(destination))
+        sdk.list_payments(req)
+        # ANCHOR_END: list-payments-details-destination
     except Exception as error:
         logging.error(error)
         raise

--- a/snippets/python/src/pay_onchain.py
+++ b/snippets/python/src/pay_onchain.py
@@ -1,5 +1,5 @@
 import logging
-from breez_sdk_liquid import BindingLiquidSdk, PreparePayOnchainRequest, PreparePayOnchainResponse, PayOnchainAmount, PayOnchainRequest
+from breez_sdk_liquid import BindingLiquidSdk, PreparePayOnchainRequest, PreparePayOnchainResponse, PayAmount, PayOnchainRequest
 
 
 def fetch_pay_onchain_limits(sdk: BindingLiquidSdk):
@@ -17,7 +17,7 @@ def fetch_pay_onchain_limits(sdk: BindingLiquidSdk):
 def prepare_pay_onchain(sdk: BindingLiquidSdk):
     # ANCHOR: prepare-pay-onchain
     try:
-        amount = PayOnchainAmount.RECEIVER(5_000)
+        amount = PayAmount.RECEIVER(5_000)
         prepare_request = PreparePayOnchainRequest(amount)
         prepare_response = sdk.prepare_pay_onchain(prepare_request)
 
@@ -31,7 +31,7 @@ def prepare_pay_onchain(sdk: BindingLiquidSdk):
 def prepare_pay_onchain_drain(sdk: BindingLiquidSdk):
     # ANCHOR: prepare-pay-onchain-drain
     try:
-        amount = PayOnchainAmount.DRAIN
+        amount = PayAmount.DRAIN
         prepare_request = PreparePayOnchainRequest(amount)
         prepare_response = sdk.prepare_pay_onchain(prepare_request)
 
@@ -45,7 +45,7 @@ def prepare_pay_onchain_drain(sdk: BindingLiquidSdk):
 def prepare_pay_onchain_fee_rate(sdk: BindingLiquidSdk):
     # ANCHOR: prepare-pay-onchain-fee-rate
     try:
-        amount = PayOnchainAmount.RECEIVER(5_000)
+        amount = PayAmount.RECEIVER(5_000)
         optional_sat_per_vbyte = 21
 
         prepare_request = PreparePayOnchainRequest(amount, optional_sat_per_vbyte)

--- a/snippets/python/src/send_payment.py
+++ b/snippets/python/src/send_payment.py
@@ -1,5 +1,5 @@
 import logging
-from breez_sdk_liquid import BindingLiquidSdk, PrepareSendRequest, SendPaymentRequest, PrepareSendResponse
+from breez_sdk_liquid import BindingLiquidSdk, PayAmount, PrepareSendRequest, SendPaymentRequest, PrepareSendResponse
 
 
 def prepare_send_payment_lightning(sdk: BindingLiquidSdk):
@@ -23,8 +23,9 @@ def prepare_send_payment_liquid(sdk: BindingLiquidSdk):
     # Set the Liquid BIP21 or Liquid address you wish to pay
     destination = "<Liquid BIP21 or address>"
     try:
-        optional_amount_sat = 5_000
-        prepare_response = sdk.prepare_send_payment(PrepareSendRequest(destination, optional_amount_sat))
+        optional_amount = PayAmount.RECEIVER(5_000)
+
+        prepare_response = sdk.prepare_send_payment(PrepareSendRequest(destination, optional_amount))
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
@@ -34,6 +35,24 @@ def prepare_send_payment_liquid(sdk: BindingLiquidSdk):
         logging.error(error)
         raise
     # ANCHOR_END: prepare-send-payment-liquid
+
+def prepare_send_payment_liquid_drain(sdk: BindingLiquidSdk):
+    # ANCHOR: prepare-send-payment-liquid-drain
+    # Set the Liquid BIP21 or Liquid address you wish to pay
+    destination = "<Liquid BIP21 or address>"
+    try:
+        optional_amount = PayAmount.DRAIN
+
+        prepare_response = sdk.prepare_send_payment(PrepareSendRequest(destination, optional_amount))
+
+        # If the fees are acceptable, continue to create the Send Payment
+        send_fees_sat = prepare_response.fees_sat
+        logging.debug("Fees: ", send_fees_sat, " sats")
+        return prepare_response
+    except Exception as error:
+        logging.error(error)
+        raise
+    # ANCHOR_END: prepare-send-payment-liquid-drain
 
 def send_payment(sdk: BindingLiquidSdk, prepare_response: PrepareSendResponse):
     # ANCHOR: send-payment

--- a/snippets/react-native/list_payments.ts
+++ b/snippets/react-native/list_payments.ts
@@ -44,7 +44,7 @@ const exampleListPaymentsDetailsAddress = async () => {
     const payments = await listPayments({
       details: {
         type: ListPaymentDetailsVariant.BITCOIN,
-        address: "<Bitcoin address>"
+        address: '<Bitcoin address>'
       }
     })
   } catch (err) {
@@ -59,7 +59,7 @@ const exampleListPaymentsDetailsDestination = async () => {
     const payments = await listPayments({
       details: {
         type: ListPaymentDetailsVariant.LIQUID,
-        destination: "<Liquid BIP21 or address>"
+        destination: '<Liquid BIP21 or address>'
       }
     })
   } catch (err) {

--- a/snippets/react-native/list_payments.ts
+++ b/snippets/react-native/list_payments.ts
@@ -1,6 +1,7 @@
 import {
   getPayment,
   GetPaymentRequestVariant,
+  ListPaymentDetailsVariant,
   listPayments,
   PaymentType
 } from '@breeztech/react-native-breez-sdk-liquid'
@@ -35,4 +36,34 @@ const exampleListPaymentsFiltered = async () => {
     console.error(err)
   }
   // ANCHOR_END: list-payments-filtered
+}
+
+const exampleListPaymentsDetailsAddress = async () => {
+  // ANCHOR: list-payments-details-address
+  try {
+    const payments = await listPayments({
+      details: {
+        type: ListPaymentDetailsVariant.BITCOIN,
+        address: "<Bitcoin address>"
+      }
+    })
+  } catch (err) {
+    console.error(err)
+  }
+  // ANCHOR_END: list-payments-details-address
+}
+
+const exampleListPaymentsDetailsDestination = async () => {
+  // ANCHOR: list-payments-details-destination
+  try {
+    const payments = await listPayments({
+      details: {
+        type: ListPaymentDetailsVariant.LIQUID,
+        destination: "<Liquid BIP21 or address>"
+      }
+    })
+  } catch (err) {
+    console.error(err)
+  }
+  // ANCHOR_END: list-payments-details-destination
 }

--- a/snippets/react-native/package.json
+++ b/snippets/react-native/package.json
@@ -10,7 +10,7 @@
         "compile": "tsc"
     },
     "dependencies": {
-        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc4",
+        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc8",
         "react": "18.1.0",
         "react-native": "0.70.6"
     },

--- a/snippets/react-native/package.json
+++ b/snippets/react-native/package.json
@@ -10,7 +10,7 @@
         "compile": "tsc"
     },
     "dependencies": {
-        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc1",
+        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc4",
         "react": "18.1.0",
         "react-native": "0.70.6"
     },

--- a/snippets/react-native/pay_onchain.ts
+++ b/snippets/react-native/pay_onchain.ts
@@ -1,10 +1,9 @@
 import {
   type PreparePayOnchainResponse,
-  type PayOnchainAmount,
   fetchOnchainLimits,
   preparePayOnchain,
   payOnchain,
-  PayOnchainAmountVariant
+  PayAmountVariant
 } from '@breeztech/react-native-breez-sdk-liquid'
 
 const exampleGetCurrentLimits = async () => {
@@ -25,7 +24,7 @@ const examplePreparePayOnchain = async () => {
   try {
     const prepareResponse = await preparePayOnchain({
       amount: {
-        type: PayOnchainAmountVariant.RECEIVER,
+        type: PayAmountVariant.RECEIVER,
         amountSat: 5_000
       }
     })
@@ -43,7 +42,7 @@ const examplePreparePayOnchainDrain = async () => {
   try {
     const prepareResponse = await preparePayOnchain({
       amount: {
-        type: PayOnchainAmountVariant.DRAIN
+        type: PayAmountVariant.DRAIN
       }
     })
 
@@ -62,7 +61,7 @@ const examplePreparePayOnchainFeeRate = async () => {
 
     const prepareResponse = await preparePayOnchain({
       amount: {
-        type: PayOnchainAmountVariant.RECEIVER,
+        type: PayAmountVariant.RECEIVER,
         amountSat: 5_000
       },
       feeRateSatPerVbyte: optionalSatPerVbyte

--- a/snippets/react-native/send_payment.ts
+++ b/snippets/react-native/send_payment.ts
@@ -1,6 +1,8 @@
 import {
   prepareSendPayment,
   sendPayment,
+  type PayAmount,
+  PayAmountVariant,
   type PrepareSendResponse
 } from '@breeztech/react-native-breez-sdk-liquid'
 
@@ -20,16 +22,38 @@ const examplePrepareSendPaymentLightning = async () => {
 const examplePrepareSendPaymentLiquid = async () => {
   // ANCHOR: prepare-send-payment-liquid
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  const optionalAmountSat = 5_000
+  const optionalAmount: PayAmount = {
+    type: PayAmountVariant.RECEIVER,
+    amountSat: 5_000
+  }
+
   const prepareResponse = await prepareSendPayment({
     destination: '<Liquid BIP21 or address>',
-    amountSat: optionalAmountSat
+    amount: optionalAmount
   })
 
   // If the fees are acceptable, continue to create the Send Payment
   const sendFeesSat = prepareResponse.feesSat
   console.log(`Fees: ${sendFeesSat} sats`)
   // ANCHOR_END: prepare-send-payment-liquid
+}
+
+const examplePrepareSendPaymentLiquidDrain = async () => {
+  // ANCHOR: prepare-send-payment-liquid-drain
+  // Set the Liquid BIP21 or Liquid address you wish to pay
+  const optionalAmount: PayAmount = {
+    type: PayAmountVariant.DRAIN,
+  }
+
+  const prepareResponse = await prepareSendPayment({
+    destination: '<Liquid BIP21 or address>',
+    amount: optionalAmount
+  })
+
+  // If the fees are acceptable, continue to create the Send Payment
+  const sendFeesSat = prepareResponse.feesSat
+  console.log(`Fees: ${sendFeesSat} sats`)
+  // ANCHOR_END: prepare-send-payment-liquid-drain
 }
 
 const exampleSendPayment = async (prepareResponse: PrepareSendResponse) => {

--- a/snippets/react-native/send_payment.ts
+++ b/snippets/react-native/send_payment.ts
@@ -42,7 +42,7 @@ const examplePrepareSendPaymentLiquidDrain = async () => {
   // ANCHOR: prepare-send-payment-liquid-drain
   // Set the Liquid BIP21 or Liquid address you wish to pay
   const optionalAmount: PayAmount = {
-    type: PayAmountVariant.DRAIN,
+    type: PayAmountVariant.DRAIN
   }
 
   const prepareResponse = await prepareSendPayment({

--- a/snippets/react-native/yarn.lock
+++ b/snippets/react-native/yarn.lock
@@ -703,10 +703,10 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
-"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc4":
-  version "0.5.0-rc4"
-  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc4.tgz#01151c7260f0d8c855f9f131ae449dee016f7afb"
-  integrity sha512-QUdmNODXU4jhhsV5LIv//4El2c8QJyVpIrZ+CmQuHmBjRaPvMblOSajoMFx2fgm/TzHHNIS705h1YA4KHHte5Q==
+"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc8":
+  version "0.5.0-rc8"
+  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc8.tgz#a1dc7c004a336aa6ba8f5dc385bb3eda4ff0c449"
+  integrity sha512-d3YNCUcdYknTeotGy2xFSDZuXTSwdkBvNjk+C9PpfkT+eT53JleKs2cWxOidDhhZ26g+K33Us3LpCaQc7DvSpg==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"

--- a/snippets/react-native/yarn.lock
+++ b/snippets/react-native/yarn.lock
@@ -703,10 +703,10 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
-"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc1":
-  version "0.5.0-rc1"
-  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc1.tgz#4fd6c374920da4d90546dcea5ce017e54e21d121"
-  integrity sha512-WGdgtwSQ8SJUJCbg4u20fa8qeBMV0dATiwj1f+j5MHGN5aYZzq4z27Xc/i0iVitoxLjvIS/zCGpohmCKefcR4g==
+"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc4":
+  version "0.5.0-rc4"
+  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc4.tgz#01151c7260f0d8c855f9f131ae449dee016f7afb"
+  integrity sha512-QUdmNODXU4jhhsV5LIv//4El2c8QJyVpIrZ+CmQuHmBjRaPvMblOSajoMFx2fgm/TzHHNIS705h1YA4KHHte5Q==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"

--- a/snippets/rust/Cargo.lock
+++ b/snippets/rust/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +400,12 @@ name = "bech32"
 version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip21"
@@ -440,12 +462,29 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "base64 0.21.7",
  "bech32 0.10.0-beta",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "hex-conservative 0.1.2",
  "hex_lit",
  "secp256k1 0.28.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
@@ -458,10 +497,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -484,9 +544,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -559,8 +629,8 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-liquid"
-version = "0.5.0-rc4"
-source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc4#498c51d013cd7127bf657da1d16f2777671d4c7f"
+version = "0.5.0-rc8"
+source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc8#c4c17e40a46da6d3c0b2c9c2f91e13d43e039ac2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -573,6 +643,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "lightning 0.0.125",
  "log",
  "lwk_common",
  "lwk_signer",
@@ -1330,6 +1401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1786,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
 dependencies = [
  "bitcoin 0.30.2",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-invoice 0.32.0",
+ "lightning-types",
 ]
 
 [[package]]
@@ -1734,6 +1826,28 @@ dependencies = [
  "lightning 0.0.122",
  "num-traits",
  "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -1899,7 +2013,7 @@ checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin 0.31.2",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
 ]
 
 [[package]]
@@ -2780,8 +2894,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
+version = "0.6.2"
+source = "git+https://github.com/breez/breez-sdk?rev=5955216ec4ed003972b4473a77207dfb744da882#5955216ec4ed003972b4473a77207dfb744da882"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -2842,6 +2956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2988,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/snippets/rust/Cargo.lock
+++ b/snippets/rust/Cargo.lock
@@ -539,7 +539,7 @@ dependencies = [
 [[package]]
 name = "boltz-client"
 version = "0.1.3"
-source = "git+https://github.com/hydra-yse/boltz-rust?branch=yse-fee-calculation#09710fb508a2a188978f37c091ebb488331d627d"
+source = "git+https://github.com/SatoshiPortal/boltz-rust?branch=trunk#19e01071f5722c21f80ae9b34edef5c3972e9e0b"
 dependencies = [
  "bip39",
  "bitcoin 0.31.2",
@@ -559,8 +559,8 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-liquid"
-version = "0.5.0-rc1"
-source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc1#5475f142cfc51ca38e9d95a184d000001754b095"
+version = "0.5.0-rc4"
+source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc4#498c51d013cd7127bf657da1d16f2777671d4c7f"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -1836,7 +1836,7 @@ dependencies = [
 [[package]]
 name = "lwk_wollet"
 version = "0.7.0"
-source = "git+https://github.com/dangeross/lwk?branch=savage-try-headers-subscribe#452bc5e07ab6b9a5fee8c2dae5c9e24d5e3cc9c5"
+source = "git+https://github.com/dangeross/lwk?branch=savage-full-scan-to-index#ccc2c70404e07e7c79cb28db460b005f13be931c"
 dependencies = [
  "aes-gcm-siv",
  "base64 0.21.7",
@@ -2112,7 +2112,17 @@ checksum = "7d17b78036a60663b797adeaee46f5c9dfebb86948d1255007a1d6be0271ff99"
 dependencies = [
  "instant",
  "lock_api",
- "parking_lot_core",
+ "parking_lot_core 0.8.6",
+]
+
+[[package]]
+name = "parking_lot"
+version = "0.12.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f1bf18183cf54e8d6059647fc3063646a1801cf30896933ec2311622cc4b9a27"
+dependencies = [
+ "lock_api",
+ "parking_lot_core 0.9.10",
 ]
 
 [[package]]
@@ -2124,9 +2134,22 @@ dependencies = [
  "cfg-if",
  "instant",
  "libc",
- "redox_syscall",
+ "redox_syscall 0.2.16",
  "smallvec",
  "winapi",
+]
+
+[[package]]
+name = "parking_lot_core"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e401f977ab385c9e4e3ab30627d6f26d00e2c73eef317493c4ec6d468726cf8"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.5.7",
+ "smallvec",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -2404,6 +2427,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fb5a58c1855b4b6819d59012155603f0b22ad30cad752600aadfcb695265519a"
 dependencies = [
  "bitflags 1.3.2",
+]
+
+[[package]]
+name = "redox_syscall"
+version = "0.5.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9b6dfecf2c74bce2466cabf93f6664d6998a69eb21e39f4207930065b27b771f"
+dependencies = [
+ "bitflags 2.6.0",
 ]
 
 [[package]]
@@ -2749,7 +2781,7 @@ dependencies = [
 [[package]]
 name = "sdk-common"
 version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=387e37f8ce48ee841762b945137e2c6b4b4b5cfa#387e37f8ce48ee841762b945137e2c6b4b4b5cfa"
+source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -2770,6 +2802,7 @@ dependencies = [
  "serde_json",
  "strum_macros",
  "thiserror",
+ "tokio",
  "tonic",
  "tonic-build",
  "url",
@@ -2991,6 +3024,15 @@ name = "shlex"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0fda2ff0d084019ba4d7c6f371c95d8fd75ce3524c3cb8fb653a3023f6323e64"
+
+[[package]]
+name = "signal-hook-registry"
+version = "1.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
+dependencies = [
+ "libc",
+]
 
 [[package]]
 name = "slab"
@@ -3253,7 +3295,9 @@ dependencies = [
  "bytes",
  "libc",
  "mio",
+ "parking_lot 0.12.3",
  "pin-project-lite",
+ "signal-hook-registry",
  "socket2",
  "tokio-macros",
  "windows-sys 0.52.0",
@@ -3698,7 +3742,7 @@ checksum = "be0ecb0db480561e9a7642b5d3e4187c128914e58aa84330b9493e3eb68c5e7f"
 dependencies = [
  "futures",
  "js-sys",
- "parking_lot",
+ "parking_lot 0.11.2",
  "pin-utils",
  "wasm-bindgen",
  "wasm-bindgen-futures",

--- a/snippets/rust/Cargo.toml
+++ b/snippets/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 bip39 = { version = "2", features = ["rand"] }
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc1" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
 log = "0.4"
 tokio = "1.29"
 

--- a/snippets/rust/Cargo.toml
+++ b/snippets/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 bip39 = { version = "2", features = ["rand"] }
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc8" }
 log = "0.4"
 tokio = "1.29"
 

--- a/snippets/rust/src/list_payments.rs
+++ b/snippets/rust/src/list_payments.rs
@@ -38,3 +38,43 @@ async fn list_payments_filtered(sdk: Arc<LiquidSdk>) -> Result<Vec<Payment>> {
 
     Ok(payments)
 }
+
+async fn list_payments_details_address(sdk: Arc<LiquidSdk>) -> Result<Vec<Payment>> {
+    // ANCHOR: list-payments-details-address
+    let address = "<Bitcoin address>".to_string();
+    let payments = sdk
+        .list_payments(&ListPaymentsRequest {
+            filters: None,
+            from_timestamp: None,
+            to_timestamp: None,
+            offset: None,
+            limit: None,
+            details: Some(ListPaymentDetails::Bitcoin {
+                address,
+            }),            
+        })
+        .await?;
+    // ANCHOR_END: list-payments-details-address
+
+    Ok(payments)
+}
+
+async fn list_payments_details_destination(sdk: Arc<LiquidSdk>) -> Result<Vec<Payment>> {
+    // ANCHOR: list-payments-details-destination
+    let destination = "<Liquid BIP21 or address>".to_string();
+    let payments = sdk
+        .list_payments(&ListPaymentsRequest {
+            filters: None,
+            from_timestamp: None,
+            to_timestamp: None,
+            offset: None,
+            limit: None,
+            details: Some(ListPaymentDetails::Liquid {
+                destination,
+            }),            
+        })
+        .await?;
+    // ANCHOR_END: list-payments-details-addrdestinationess
+
+    Ok(payments)
+}

--- a/snippets/rust/src/pay_onchain.rs
+++ b/snippets/rust/src/pay_onchain.rs
@@ -19,7 +19,7 @@ async fn prepare_pay_onchain(sdk: Arc<LiquidSdk>) -> Result<()> {
     // ANCHOR: prepare-pay-onchain
     let prepare_res = sdk
         .prepare_pay_onchain(&PreparePayOnchainRequest {
-            amount: PayOnchainAmount::Receiver {
+            amount: PayAmount::Receiver {
                 amount_sat: 5_000,
             },
             fee_rate_sat_per_vbyte: None,
@@ -37,7 +37,7 @@ async fn prepare_pay_onchain_drain(sdk: Arc<LiquidSdk>) -> Result<()> {
     // ANCHOR: prepare-pay-onchain-drain
     let prepare_res = sdk
         .prepare_pay_onchain(&PreparePayOnchainRequest {
-            amount: PayOnchainAmount::Drain,
+            amount: PayAmount::Drain,
             fee_rate_sat_per_vbyte: None,
         })
         .await?;
@@ -55,7 +55,7 @@ async fn prepare_pay_onchain_fee_rate(sdk: Arc<LiquidSdk>) -> Result<()> {
 
     let prepare_res = sdk
         .prepare_pay_onchain(&PreparePayOnchainRequest {
-            amount: PayOnchainAmount::Receiver {
+            amount: PayAmount::Receiver {
                 amount_sat: 5_000,
             },
             fee_rate_sat_per_vbyte: optional_sat_per_vbyte,

--- a/snippets/rust/src/send_payment.rs
+++ b/snippets/rust/src/send_payment.rs
@@ -24,11 +24,13 @@ async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
 async fn prepare_send_payment_liquid(sdk: Arc<LiquidSdk>) -> Result<()> {
     // ANCHOR: prepare-send-payment-liquid
     // Set the Liquid BIP21 or Liquid address you wish to pay
-    let optional_amount_sat = Some(5_000);
+    let optional_amount = Some(PayAmount::Receiver {
+        amount_sat: 5_000,
+    });
     let prepare_response = sdk
         .prepare_send_payment(&PrepareSendRequest {
             destination: "<Liquid BIP21 or address>".to_string(),
-            amount_sat: optional_amount_sat,
+            amount: optional_amount,
         })
         .await?;
 
@@ -36,6 +38,24 @@ async fn prepare_send_payment_liquid(sdk: Arc<LiquidSdk>) -> Result<()> {
     let send_fees_sat = prepare_response.fees_sat;
     info!("Fees: {} sats", send_fees_sat);
     // ANCHOR_END: prepare-send-payment-liquid
+    Ok(())
+}
+
+async fn prepare_send_payment_liquid_drain(sdk: Arc<LiquidSdk>) -> Result<()> {
+    // ANCHOR: prepare-send-payment-liquid-drain
+    // Set the Liquid BIP21 or Liquid address you wish to pay
+    let optional_amount = Some(PayAmount::Drain);
+    let prepare_response = sdk
+        .prepare_send_payment(&PrepareSendRequest {
+            destination: "<Liquid BIP21 or address>".to_string(),
+            amount: optional_amount,
+        })
+        .await?;
+
+    // If the fees are acceptable, continue to create the Send Payment
+    let send_fees_sat = prepare_response.fees_sat;
+    info!("Fees: {} sats", send_fees_sat);
+    // ANCHOR_END: prepare-send-payment-liquid-drain
     Ok(())
 }
 

--- a/snippets/rust/src/send_payment.rs
+++ b/snippets/rust/src/send_payment.rs
@@ -10,7 +10,7 @@ async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
     let prepare_response = sdk
         .prepare_send_payment(&PrepareSendRequest {
             destination: "<bolt11 invoice>".to_string(),
-            amount_sat: None,
+            amount: None,
         })
         .await?;
 

--- a/snippets/swift/BreezSDKExamples/Package.resolved
+++ b/snippets/swift/BreezSDKExamples/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/breez/breez-sdk-liquid-swift",
       "state" : {
-        "revision" : "385e4ca5e52a6f13e45f149adf83c80817eb5fb6",
-        "version" : "0.5.0-rc4"
+        "revision" : "956af9ef344db6108c64c5d18faa803a70e2333e",
+        "version" : "0.5.0-rc8"
       }
     },
     {

--- a/snippets/swift/BreezSDKExamples/Package.resolved
+++ b/snippets/swift/BreezSDKExamples/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/breez/breez-sdk-liquid-swift",
       "state" : {
-        "revision" : "5aa21bc74eaef0e5a052df289da7fd7e85d26d45",
-        "version" : "0.5.0-rc1"
+        "revision" : "385e4ca5e52a6f13e45f149adf83c80817eb5fb6",
+        "version" : "0.5.0-rc4"
       }
     },
     {

--- a/snippets/swift/BreezSDKExamples/Package.swift
+++ b/snippets/swift/BreezSDKExamples/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [.macOS("15.0")],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
-        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc4")
+        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc8")
         // To use a local version of breez-sdk-liquid, comment-out the above and un-comment:
         // .package(name: "bindings-swift", path: "/local-path/breez-sdk-liquid/lib/bindings/langs/swift")
     ],

--- a/snippets/swift/BreezSDKExamples/Package.swift
+++ b/snippets/swift/BreezSDKExamples/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [.macOS("15.0")],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
-        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc1")
+        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc4")
         // To use a local version of breez-sdk-liquid, comment-out the above and un-comment:
         // .package(name: "bindings-swift", path: "/local-path/breez-sdk-liquid/lib/bindings/langs/swift")
     ],

--- a/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
@@ -37,7 +37,7 @@ func ListPaymentsDetailsAddress(sdk: BindingLiquidSdk) -> [Payment]? {
     let address = "<Bitcoin address>"
     let payments = try? sdk.listPayments(
         req: ListPaymentsRequest(
-            details: ListPaymentDetails.Bitcoin(address: address)
+            details: ListPaymentDetails.bitcoin(address: address)
         ))
     // ANCHOR_END: list-payments-details-address
     return payments
@@ -48,7 +48,7 @@ func ListPaymentsDetailsDestination(sdk: BindingLiquidSdk) -> [Payment]? {
     let destination = "<Liquid BIP21 or address>"
     let payments = try? sdk.listPayments(
         req: ListPaymentsRequest(
-            details: ListPaymentDetails.Bitcoin(destination: destination)
+            details: ListPaymentDetails.liquid(destination: destination)
         ))
     // ANCHOR_END: list-payments-details-destination
     return payments

--- a/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
@@ -31,3 +31,25 @@ func ListPaymentsFiltered(sdk: BindingLiquidSdk) -> [Payment]? {
     // ANCHOR_END: list-payments-filtered
     return payments
 }
+
+func ListPaymentsDetailsAddress(sdk: BindingLiquidSdk) -> [Payment]? {
+    // ANCHOR: list-payments-details-address
+    let address = "<Bitcoin address>"
+    let payments = try? sdk.listPayments(
+        req: ListPaymentsRequest(
+            details: ListPaymentDetails.Bitcoin(address: address)
+        ))
+    // ANCHOR_END: list-payments-details-address
+    return payments
+}
+
+func ListPaymentsDetailsDestination(sdk: BindingLiquidSdk) -> [Payment]? {
+    // ANCHOR: list-payments-details-destination
+    let destination = "<Liquid BIP21 or address>"
+    let payments = try? sdk.listPayments(
+        req: ListPaymentsRequest(
+            details: ListPaymentDetails.Bitcoin(destination: destination)
+        ))
+    // ANCHOR_END: list-payments-details-destination
+    return payments
+}

--- a/snippets/swift/BreezSDKExamples/Sources/PayOnchain.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/PayOnchain.swift
@@ -14,7 +14,7 @@ func getCurrentLimits(sdk: BindingLiquidSdk) -> OnchainPaymentLimitsResponse?? {
 
 func preparePayOnchain(sdk: BindingLiquidSdk, currentLimits: Limits) -> PreparePayOnchainResponse? {
     // ANCHOR: prepare-pay-onchain
-    let amount = PayOnchainAmount.receiver(amountSat: 5_000)
+    let amount = PayAmount.receiver(amountSat: 5_000)
     let prepareRequest = PreparePayOnchainRequest(amount: amount)
     let prepareResponse = try? sdk.preparePayOnchain(req: prepareRequest)
 
@@ -28,7 +28,7 @@ func preparePayOnchain(sdk: BindingLiquidSdk, currentLimits: Limits) -> PrepareP
 
 func preparePayOnchainDrain(sdk: BindingLiquidSdk, currentLimits: Limits) -> PreparePayOnchainResponse? {
     // ANCHOR: prepare-pay-onchain-drain
-    let amount = PayOnchainAmount.drain
+    let amount = PayAmount.drain
     let prepareRequest = PreparePayOnchainRequest(amount: amount)
     let prepareResponse = try? sdk.preparePayOnchain(req: prepareRequest)
 
@@ -42,7 +42,7 @@ func preparePayOnchainDrain(sdk: BindingLiquidSdk, currentLimits: Limits) -> Pre
 
 func preparePayOnchainFeeRate(sdk: BindingLiquidSdk, currentLimits: Limits) -> PreparePayOnchainResponse? {
     // ANCHOR: prepare-pay-onchain-fee-rate
-    let amount = PayOnchainAmount.receiver(amountSat: 5_000)
+    let amount = PayAmount.receiver(amountSat: 5_000)
     let optionalSatPerVbyte = UInt32(21)
 
     let prepareRequest = PreparePayOnchainRequest(amount: amount, feeRateSatPerVbyte: optionalSatPerVbyte)

--- a/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/SendPayment.swift
@@ -18,17 +18,36 @@ func prepareSendPaymentLightning(sdk: BindingLiquidSdk) -> PrepareSendResponse? 
 func prepareSendPaymentLiquid(sdk: BindingLiquidSdk) -> PrepareSendResponse? {
     // ANCHOR: prepare-send-payment-liquid
     // Set the Liquid BIP21 or Liquid address you wish to pay
-    let optionalAmountSat: UInt64? = Optional.some(5000)
+    let optionalAmount = PayAmount.receiver(amountSat: 5_000)
+
     let prepareResponse = try? sdk
         .prepareSendPayment(req: PrepareSendRequest (
             destination: "<Liquid BIP21 or address>",
-            amountSat: optionalAmountSat
+            amount: optionalAmount
         ))
 
     // If the fees are acceptable, continue to create the Send Payment
     let sendFeesSat = prepareResponse!.feesSat
     print("Fees: {} sats", sendFeesSat);
     // ANCHOR_END: prepare-send-payment-liquid
+    return prepareResponse
+}
+
+func prepareSendPaymentLiquidDrain(sdk: BindingLiquidSdk) -> PrepareSendResponse? {
+    // ANCHOR: prepare-send-payment-liquid-drain
+    // Set the Liquid BIP21 or Liquid address you wish to pay
+    let optionalAmount = PayAmount.drain
+
+    let prepareResponse = try? sdk
+        .prepareSendPayment(req: PrepareSendRequest (
+            destination: "<Liquid BIP21 or address>",
+            amount: optionalAmount
+        ))
+
+    // If the fees are acceptable, continue to create the Send Payment
+    let sendFeesSat = prepareResponse!.feesSat
+    print("Fees: {} sats", sendFeesSat);
+    // ANCHOR_END: prepare-send-payment-liquid-drain
     return prepareResponse
 }
 

--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -91,7 +91,7 @@ Check https://github.com/breez/breez-sdk-liquid/releases for the latest version.
 
 ```toml
 [dependencies]
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc8" }
 
 [patch.crates-io]
 secp256k1-zkp = {git = "https://github.com/sanket1729/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}

--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -91,7 +91,7 @@ Check https://github.com/breez/breez-sdk-liquid/releases for the latest version.
 
 ```toml
 [dependencies]
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc1" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
 
 [patch.crates-io]
 secp256k1-zkp = {git = "https://github.com/sanket1729/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}

--- a/src/guide/list_payments.md
+++ b/src/guide/list_payments.md
@@ -68,7 +68,10 @@ To view your payment history you can list all the sent and received payments mad
 </section>
 </custom-tabs>
 
-You can optionally filter payments by timestamp and type.
+## Filtering Payments
+
+When listing payment you can also filter and page the list results, by:
+### Type and timestamp
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -132,6 +135,142 @@ You can optionally filter payments by timestamp and type.
 
 ```cs,ignore
 {{#include ../../snippets/csharp/ListPayments.cs:list-payments-filtered}}
+```
+</section>
+</custom-tabs>
+
+### Bitcoin address
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/list_payments.rs:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/ListPayments.swift:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ListPayments.kt:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/list_payments.ts:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/list_payments.dart:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/list_payments.py:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/list_payments.go:list-payments-details-address}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/ListPayments.cs:list-payments-details-address}}
+```
+</section>
+</custom-tabs>
+
+### Liquid destination
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/list_payments.rs:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/ListPayments.swift:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/ListPayments.kt:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/list_payments.ts:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/list_payments.dart:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/list_payments.py:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/list_payments.go:list-payments-details-destination}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/ListPayments.cs:list-payments-details-destination}}
 ```
 </section>
 </custom-tabs>

--- a/src/guide/send_payment.md
+++ b/src/guide/send_payment.md
@@ -98,7 +98,7 @@ To learn more about this process and how it works in detail, see the Boltz docum
 
 For onchain (Bitcoin) payments, see [Sending an on-chain transaction](pay_onchain.md).
 
-<h3>Liquid</h3>
+### Liquid
 When sending via Liquid, a BIP21 URI or Liquid address can be used as the destination. 
 
 If a Liquid address is used, the optional prepare request amount **must** be set. 
@@ -106,6 +106,9 @@ If a Liquid address is used, the optional prepare request amount **must** be set
 If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request amount **must** be set. When both amounts are set, the SDK will prioritize the **request amount** over the BIP21 amount.
 
 **Note:** If a valid Breez API key is not provided, the method will throw an error requiring you to specify one.
+
+#### Setting the receiver amount
+When you want the payment receipient to receive a specific amount.
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -172,6 +175,76 @@ If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request 
 ```
 </section>
 </custom-tabs>
+
+#### Draining all funds
+When you want send all funds from your wallet to another address.
+
+<custom-tabs category="lang">
+<div slot="title">Rust</div>
+<section>
+
+```rust,ignore
+{{#include ../../snippets/rust/src/send_payment.rs:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">Swift</div>
+<section>
+
+```swift,ignore
+{{#include ../../snippets/swift/BreezSDKExamples/Sources/SendPayment.swift:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">Kotlin</div>
+<section>
+
+```kotlin,ignore
+{{#include ../../snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/SendPayment.kt:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">React Native</div>
+<section>
+
+```typescript
+{{#include ../../snippets/react-native/send_payment.ts:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">Dart</div>
+<section>
+
+```dart,ignore
+{{#include ../../snippets/dart_snippets/lib/send_payment.dart:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">Python</div>
+<section>
+
+```python,ignore 
+{{#include ../../snippets/python/src/send_payment.py:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">Go</div>
+<section>
+
+```go,ignore
+{{#include ../../snippets/go/send_payment.go:prepare-send-payment-liquid-drain}}
+```
+</section>
+
+<div slot="title">C#</div>
+<section>
+
+```cs,ignore
+{{#include ../../snippets/csharp/SendPayment.cs:prepare-send-payment-liquid-drain}}
+```
+</section>
+</custom-tabs>
+
 
 ## Sending Payments
 Once the payment has been prepared, all you have to do is pass the prepare response as an argument to the


### PR DESCRIPTION
This PR:
- bumps SDK version to 0.5.0-rc4
- adds docs for preparing a draining when sending a Liquid payment
- adds docs for listing payments using the Bitcoin address or Liquid destination