### PR TITLE
Bump `breez-sdk-liquid` dependency to `0.5.0-rc8`

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -281,7 +281,7 @@ jobs:
 
     - uses: maxim-lobanov/setup-xcode@v1
       with:
-        xcode-version: "16.1-beta"
+        xcode-version: "latest-stable"
           
     - name: Build
       working-directory: snippets/swift/BreezSDKExamples

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,10 +11,10 @@ on:
   workflow_dispatch:
     inputs:
       sdk-ref:
-        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc4'
+        description: 'sdk commit/tag/branch reference. Defaults to 0.5.0-rc8'
         required: false
         type: string
-        default: 0.5.0-rc4
+        default: 0.5.0-rc8
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.ref }}
@@ -26,9 +26,9 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       # Used only for Rust snippets
-      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc4' }}
+      sdk-ref: ${{ inputs.sdk-ref || '0.5.0-rc8' }}
       # Used for RN and Flutter snippets
-      package-version: '0.5.0-rc4'
+      package-version: '0.5.0-rc8'
     steps:
       - run: echo "set pre-setup output variables"
 

--- a/examples/python/cli/pyproject.toml
+++ b/examples/python/cli/pyproject.toml
@@ -7,7 +7,7 @@ readme = "README.md"
 
 [tool.poetry.dependencies]
 python = "^3.8.1"
-breez-sdk-liquid = "0.5.0-rc4"
+breez-sdk-liquid = "0.5.0-rc8"
 argparse = "^1.4.0"
 qrcode = "^7.4.2"
 colorama = "^0.4.6"

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -18,7 +18,7 @@ Future<PrepareSendResponse> prepareSendPaymentLightning() async {
 Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
   // ANCHOR: prepare-send-payment-liquid
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmount = PayAmount_Receiver(amountSat: 5000 as BigInt);
+  PayAmount_Receiver optionalAmount = PayAmount_Receiver(amountSat: 5000 as BigInt);
   PrepareSendRequest prepareSendRequest = PrepareSendRequest(
     destination: "<Liquid BIP21 or address>",
     amount: optionalAmount,
@@ -38,7 +38,7 @@ Future<PrepareSendResponse> prepareSendPaymentLiquid() async {
 Future<PrepareSendResponse> prepareSendPaymentLiquidDrain() async {
   // ANCHOR: prepare-send-payment-liquid-drain
   // Set the Liquid BIP21 or Liquid address you wish to pay
-  BigInt optionalAmount = PayAmount_Drain(),
+  PayAmount_Drain optionalAmount = PayAmount_Drain();
   PrepareSendRequest prepareSendRequest = PrepareSendRequest(
     destination: "<Liquid BIP21 or address>",
     amount: optionalAmount,

--- a/snippets/dart_snippets/pubspec.lock
+++ b/snippets/dart_snippets/pubspec.lock
@@ -46,10 +46,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: d13880259533974e9551bc143bbae825f198a44d
+      resolved-ref: 619a9b23256820b291ddf97f3fee7224c5b084fd
       url: "https://github.com/breez/breez-sdk-liquid-dart"
     source: git
-    version: "0.5.0-rc4"
+    version: "0.5.0-rc8"
   build_cli_annotations:
     dependency: transitive
     description:
@@ -140,10 +140,10 @@ packages:
     description:
       path: "."
       ref: HEAD
-      resolved-ref: a40fbf0a36e4fd3f07235ca6976f3ba09563015e
+      resolved-ref: a0ee25c652159a0c99faaf55f8b21becc5b32999
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.5.0-rc4"
+    version: "0.5.0-rc8"
   flutter_rust_bridge:
     dependency: transitive
     description:

--- a/snippets/dart_snippets/pubspec.yaml
+++ b/snippets/dart_snippets/pubspec.yaml
@@ -10,11 +10,11 @@ dependencies:
   breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-dart
-      tag: 0.5.0-rc4
+      tag: 0.5.0-rc8
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
-      tag: 0.5.0-rc4
+      tag: 0.5.0-rc8
   rxdart: ^0.28.0  
 
 dependency_overrides:

--- a/snippets/go/go.mod
+++ b/snippets/go/go.mod
@@ -2,6 +2,6 @@ module main
 
 go 1.19
 
-require github.com/breez/breez-sdk-liquid-go v0.5.0-rc4
+require github.com/breez/breez-sdk-liquid-go v0.5.0-rc8
 
 //replace github.com/breez/breez-sdk-liquid-go => ./packages/breez-sdk-liquid-go

--- a/snippets/go/list_payments.go
+++ b/snippets/go/list_payments.go
@@ -64,7 +64,9 @@ func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsDestination(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-destination
 	destination := "<Liquid BIP21 or address>"
-	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsLiquid{Destination: destination}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsLiquid{
+		Destination: destination,
+	}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}

--- a/snippets/go/list_payments.go
+++ b/snippets/go/list_payments.go
@@ -49,7 +49,9 @@ func ListPaymentsFiltered(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-address
 	address := "<Bitcoin address>"
-	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsBitcoin{Address: address}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsBitcoin{
+		Address: address,
+	}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}

--- a/snippets/go/list_payments.go
+++ b/snippets/go/list_payments.go
@@ -49,7 +49,7 @@ func ListPaymentsFiltered(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-address
 	address := "<Bitcoin address>"
-	details := breez_sdk_liquid.ListPaymentDetailsBitcoin{Address: address}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsBitcoin{Address: address}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}
@@ -62,7 +62,7 @@ func ListPaymentsDetailsAddress(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 func ListPaymentsDetailsDestination(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: list-payments-details-destination
 	destination := "<Liquid BIP21 or address>"
-	details := breez_sdk_liquid.ListPaymentDetailsLiquid{Destination: destination}
+	var details breez_sdk_liquid.ListPaymentDetails = breez_sdk_liquid.ListPaymentDetailsLiquid{Destination: destination}
 	listPaymentsRequest := breez_sdk_liquid.ListPaymentsRequest{
 		Details: &details,
 	}

--- a/snippets/go/send_payment.go
+++ b/snippets/go/send_payment.go
@@ -28,7 +28,7 @@ func PrepareSendPaymentLiquid(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-send-payment-liquid
 	// Set the Liquid BIP21 or Liquid address you wish to pay
 	destination := "<Liquid BIP21 or address>"
-	optionalAmount := breez_sdk_liquid.PayAmountReceiver{AmountSat: uint64(5_000)}
+	var optionalAmount breez_sdk_liquid.PayAmount = breez_sdk_liquid.PayAmountReceiver{AmountSat: uint64(5_000)}
 
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,
@@ -49,7 +49,7 @@ func PrepareSendPaymentLiquidDrain(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: prepare-send-payment-liquid-drain
 	// Set the Liquid BIP21 or Liquid address you wish to pay
 	destination := "<Liquid BIP21 or address>"
-	optionalAmount := breez_sdk_liquid.PayAmountDrain{}
+	var optionalAmount breez_sdk_liquid.PayAmount = breez_sdk_liquid.PayAmountDrain{}
 
 	prepareRequest := breez_sdk_liquid.PrepareSendRequest{
 		Destination: destination,

--- a/snippets/kotlin_mpp_lib/shared/build.gradle.kts
+++ b/snippets/kotlin_mpp_lib/shared/build.gradle.kts
@@ -29,7 +29,7 @@ kotlin {
         }
         val commonMain by getting {
             dependencies {
-                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc4")
+                implementation("technology.breez.liquid:breez-sdk-liquid-kmp:0.5.0-rc8")
             }
         }
     }

--- a/snippets/react-native/list_payments.ts
+++ b/snippets/react-native/list_payments.ts
@@ -44,7 +44,7 @@ const exampleListPaymentsDetailsAddress = async () => {
     const payments = await listPayments({
       details: {
         type: ListPaymentDetailsVariant.BITCOIN,
-        address: "<Bitcoin address>"
+        address: '<Bitcoin address>'
       }
     })
   } catch (err) {
@@ -59,7 +59,7 @@ const exampleListPaymentsDetailsDestination = async () => {
     const payments = await listPayments({
       details: {
         type: ListPaymentDetailsVariant.LIQUID,
-        destination: "<Liquid BIP21 or address>"
+        destination: '<Liquid BIP21 or address>'
       }
     })
   } catch (err) {

--- a/snippets/react-native/package.json
+++ b/snippets/react-native/package.json
@@ -10,7 +10,7 @@
         "compile": "tsc"
     },
     "dependencies": {
-        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc4",
+        "@breeztech/react-native-breez-sdk-liquid": "^0.5.0-rc8",
         "react": "18.1.0",
         "react-native": "0.70.6"
     },

--- a/snippets/react-native/send_payment.ts
+++ b/snippets/react-native/send_payment.ts
@@ -42,7 +42,7 @@ const examplePrepareSendPaymentLiquidDrain = async () => {
   // ANCHOR: prepare-send-payment-liquid-drain
   // Set the Liquid BIP21 or Liquid address you wish to pay
   const optionalAmount: PayAmount = {
-    type: PayAmountVariant.DRAIN,
+    type: PayAmountVariant.DRAIN
   }
 
   const prepareResponse = await prepareSendPayment({

--- a/snippets/react-native/yarn.lock
+++ b/snippets/react-native/yarn.lock
@@ -703,10 +703,10 @@
     "@babel/helper-validator-identifier" "^7.24.7"
     to-fast-properties "^2.0.0"
 
-"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc4":
-  version "0.5.0-rc4"
-  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc4.tgz#01151c7260f0d8c855f9f131ae449dee016f7afb"
-  integrity sha512-QUdmNODXU4jhhsV5LIv//4El2c8QJyVpIrZ+CmQuHmBjRaPvMblOSajoMFx2fgm/TzHHNIS705h1YA4KHHte5Q==
+"@breeztech/react-native-breez-sdk-liquid@^0.5.0-rc8":
+  version "0.5.0-rc8"
+  resolved "https://registry.yarnpkg.com/@breeztech/react-native-breez-sdk-liquid/-/react-native-breez-sdk-liquid-0.5.0-rc8.tgz#a1dc7c004a336aa6ba8f5dc385bb3eda4ff0c449"
+  integrity sha512-d3YNCUcdYknTeotGy2xFSDZuXTSwdkBvNjk+C9PpfkT+eT53JleKs2cWxOidDhhZ26g+K33Us3LpCaQc7DvSpg==
 
 "@esbuild/android-arm64@0.18.20":
   version "0.18.20"

--- a/snippets/rust/Cargo.lock
+++ b/snippets/rust/Cargo.lock
@@ -195,6 +195,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "arrayvec"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
+
+[[package]]
 name = "asn1-rs"
 version = "0.6.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -356,6 +362,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "base58ck"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2c8d66485a3a2ea485c1913c4572ce0256067a5377ac8c75c4960e1cda98605f"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+ "bitcoin_hashes 0.14.0",
+]
+
+[[package]]
 name = "base64"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -384,6 +400,12 @@ name = "bech32"
 version = "0.10.0-beta"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "98f7eed2b2781a6f0b5c903471d48e15f56fb4e1165df8a9a2337fd1a59d45ea"
+
+[[package]]
+name = "bech32"
+version = "0.11.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d965446196e3b7decd44aa7ee49e31d630118f90ef12f97900f262eb915c951d"
 
 [[package]]
 name = "bip21"
@@ -440,12 +462,29 @@ checksum = "6c85783c2fe40083ea54a33aa2f0ba58831d90fcd190f5bdc47e74e84d2a96ae"
 dependencies = [
  "base64 0.21.7",
  "bech32 0.10.0-beta",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
  "bitcoin_hashes 0.13.0",
- "hex-conservative",
+ "hex-conservative 0.1.2",
  "hex_lit",
  "secp256k1 0.28.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin"
+version = "0.32.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "788902099d47c8682efe6a7afb01c8d58b9794ba66c06affd81c3d6b560743eb"
+dependencies = [
+ "base58ck",
+ "bech32 0.11.0",
+ "bitcoin-internals 0.3.0",
+ "bitcoin-io",
+ "bitcoin-units",
+ "bitcoin_hashes 0.14.0",
+ "hex-conservative 0.2.1",
+ "hex_lit",
+ "secp256k1 0.29.1",
 ]
 
 [[package]]
@@ -458,10 +497,31 @@ dependencies = [
 ]
 
 [[package]]
+name = "bitcoin-internals"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "30bdbe14aa07b06e6cfeffc529a1f099e5fbe249524f8125358604df99a4bed2"
+
+[[package]]
+name = "bitcoin-io"
+version = "0.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b47c4ab7a93edb0c7198c5535ed9b52b63095f4e9b45279c6736cec4b856baf"
+
+[[package]]
 name = "bitcoin-private"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "73290177011694f38ec25e165d0387ab7ea749a4b81cd4c80dae5988229f7a57"
+
+[[package]]
+name = "bitcoin-units"
+version = "0.1.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5285c8bcaa25876d07f37e3d30c303f2609179716e11d688f51e8f1fe70063e2"
+dependencies = [
+ "bitcoin-internals 0.3.0",
+]
 
 [[package]]
 name = "bitcoin_hashes"
@@ -484,9 +544,19 @@ version = "0.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1930a4dabfebb8d7d9992db18ebe3ae2876f0a305fab206fd168df931ede293b"
 dependencies = [
- "bitcoin-internals",
- "hex-conservative",
+ "bitcoin-internals 0.2.0",
+ "hex-conservative 0.1.2",
  "serde",
+]
+
+[[package]]
+name = "bitcoin_hashes"
+version = "0.14.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "bb18c03d0db0247e147a21a6faafd5a7eb851c743db062de72018b6b7e8e4d16"
+dependencies = [
+ "bitcoin-io",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -559,8 +629,8 @@ dependencies = [
 
 [[package]]
 name = "breez-sdk-liquid"
-version = "0.5.0-rc4"
-source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc4#498c51d013cd7127bf657da1d16f2777671d4c7f"
+version = "0.5.0-rc8"
+source = "git+https://github.com/breez/breez-sdk-liquid?tag=0.5.0-rc8#c4c17e40a46da6d3c0b2c9c2f91e13d43e039ac2"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -573,6 +643,7 @@ dependencies = [
  "futures-util",
  "glob",
  "hex",
+ "lightning 0.0.125",
  "log",
  "lwk_common",
  "lwk_signer",
@@ -1330,6 +1401,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "212ab92002354b4819390025006c897e8140934349e8635c9b077f47b4dcbd20"
 
 [[package]]
+name = "hex-conservative"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "5313b072ce3c597065a808dbf612c4c8e8590bdbf8b579508bf7a762c5eae6cd"
+dependencies = [
+ "arrayvec",
+]
+
+[[package]]
 name = "hex_lit"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1706,7 +1786,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0d9b36ae12b379905bfc429ce5d4e8ca4a55c8dd3de73074309bd0bcc053bcac"
 dependencies = [
  "bitcoin 0.30.2",
- "hex-conservative",
+ "hex-conservative 0.1.2",
+]
+
+[[package]]
+name = "lightning"
+version = "0.0.125"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "767f388e50251da71f95a3737d6db32c9729f9de6427a54fa92bb994d04d793f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-invoice 0.32.0",
+ "lightning-types",
 ]
 
 [[package]]
@@ -1734,6 +1826,28 @@ dependencies = [
  "lightning 0.0.122",
  "num-traits",
  "secp256k1 0.27.0",
+]
+
+[[package]]
+name = "lightning-invoice"
+version = "0.32.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "90ab9f6ea77e20e3129235e62a2e6bd64ed932363df104e864ee65ccffb54a8f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "lightning-types",
+]
+
+[[package]]
+name = "lightning-types"
+version = "0.1.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1083b8d9137000edf3bfcb1ff011c0d25e0cdd2feb98cc21d6765e64a494148f"
+dependencies = [
+ "bech32 0.9.1",
+ "bitcoin 0.32.4",
+ "hex-conservative 0.2.1",
 ]
 
 [[package]]
@@ -1899,7 +2013,7 @@ checksum = "3127e10529a57a8f7fa9b1332c4c2f72baadaca6777798f910dff3c922620b14"
 dependencies = [
  "bech32 0.10.0-beta",
  "bitcoin 0.31.2",
- "bitcoin-internals",
+ "bitcoin-internals 0.2.0",
 ]
 
 [[package]]
@@ -2780,8 +2894,8 @@ dependencies = [
 
 [[package]]
 name = "sdk-common"
-version = "0.5.2"
-source = "git+https://github.com/breez/breez-sdk?rev=441a9fd50c32098b2887e960c8a4bcc5956da1af#441a9fd50c32098b2887e960c8a4bcc5956da1af"
+version = "0.6.2"
+source = "git+https://github.com/breez/breez-sdk?rev=5955216ec4ed003972b4473a77207dfb744da882#5955216ec4ed003972b4473a77207dfb744da882"
 dependencies = [
  "aes 0.8.4",
  "anyhow",
@@ -2842,6 +2956,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "secp256k1"
+version = "0.29.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9465315bc9d4566e1724f0fffcbcc446268cb522e60f9a27bcded6b19c108113"
+dependencies = [
+ "bitcoin_hashes 0.12.0",
+ "secp256k1-sys 0.10.1",
+]
+
+[[package]]
 name = "secp256k1-sys"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2864,6 +2988,15 @@ name = "secp256k1-sys"
 version = "0.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5d1746aae42c19d583c3c1a8c646bfad910498e2051c551a7f2e3c0c9fbb7eb"
+dependencies = [
+ "cc",
+]
+
+[[package]]
+name = "secp256k1-sys"
+version = "0.10.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4387882333d3aa8cb20530a17c69a3752e97837832f34f6dccc760e715001d9"
 dependencies = [
  "cc",
 ]

--- a/snippets/rust/Cargo.toml
+++ b/snippets/rust/Cargo.toml
@@ -6,7 +6,7 @@ edition = "2021"
 [dependencies]
 anyhow = "1"
 bip39 = { version = "2", features = ["rand"] }
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc8" }
 log = "0.4"
 tokio = "1.29"
 

--- a/snippets/rust/src/send_payment.rs
+++ b/snippets/rust/src/send_payment.rs
@@ -10,7 +10,7 @@ async fn prepare_send_payment_lightning(sdk: Arc<LiquidSdk>) -> Result<()> {
     let prepare_response = sdk
         .prepare_send_payment(&PrepareSendRequest {
             destination: "<bolt11 invoice>".to_string(),
-            amount_sat: None,
+            amount: None,
         })
         .await?;
 

--- a/snippets/swift/BreezSDKExamples/Package.resolved
+++ b/snippets/swift/BreezSDKExamples/Package.resolved
@@ -5,8 +5,8 @@
       "kind" : "remoteSourceControl",
       "location" : "https://github.com/breez/breez-sdk-liquid-swift",
       "state" : {
-        "revision" : "385e4ca5e52a6f13e45f149adf83c80817eb5fb6",
-        "version" : "0.5.0-rc4"
+        "revision" : "956af9ef344db6108c64c5d18faa803a70e2333e",
+        "version" : "0.5.0-rc8"
       }
     },
     {

--- a/snippets/swift/BreezSDKExamples/Package.swift
+++ b/snippets/swift/BreezSDKExamples/Package.swift
@@ -8,7 +8,7 @@ let package = Package(
     platforms: [.macOS("15.0")],
     dependencies: [
         .package(url: "https://github.com/apple/swift-argument-parser", from: "1.2.3"),
-        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc4")
+        .package(url: "https://github.com/breez/breez-sdk-liquid-swift", from:"0.5.0-rc8")
         // To use a local version of breez-sdk-liquid, comment-out the above and un-comment:
         // .package(name: "bindings-swift", path: "/local-path/breez-sdk-liquid/lib/bindings/langs/swift")
     ],

--- a/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/ListPayments.swift
@@ -37,7 +37,7 @@ func ListPaymentsDetailsAddress(sdk: BindingLiquidSdk) -> [Payment]? {
     let address = "<Bitcoin address>"
     let payments = try? sdk.listPayments(
         req: ListPaymentsRequest(
-            details: ListPaymentDetails.Bitcoin(address: address)
+            details: ListPaymentDetails.bitcoin(address: address)
         ))
     // ANCHOR_END: list-payments-details-address
     return payments
@@ -48,7 +48,7 @@ func ListPaymentsDetailsDestination(sdk: BindingLiquidSdk) -> [Payment]? {
     let destination = "<Liquid BIP21 or address>"
     let payments = try? sdk.listPayments(
         req: ListPaymentsRequest(
-            details: ListPaymentDetails.Bitcoin(destination: destination)
+            details: ListPaymentDetails.liquid(destination: destination)
         ))
     // ANCHOR_END: list-payments-details-destination
     return payments

--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -91,7 +91,7 @@ Check https://github.com/breez/breez-sdk-liquid/releases for the latest version.
 
 ```toml
 [dependencies]
-breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc4" }
+breez-sdk-liquid = { git = "https://github.com/breez/breez-sdk-liquid", tag = "0.5.0-rc8" }
 
 [patch.crates-io]
 secp256k1-zkp = {git = "https://github.com/sanket1729/rust-secp256k1-zkp.git", rev = "60e631c24588a0c9e271badd61959294848c665d"}


### PR DESCRIPTION
This PR bumps the SDK dependency to the latest `0.5.0-rc8` and fixes the CI errors.

Built on top of #50.