### PR TITLE
Fix responsive API docs tag

### DIFF
--- a/styles.css
+++ b/styles.css
@@ -20,7 +20,8 @@ a.tag {
     border-radius: 10px;
     border: 1px solid #fff;
     background-color: var(--searchresults-header-fg);
-    text-decoration: none;
+    white-space: nowrap;
+    max-height: 1.5em;
 }
 
 h1 a.tag {


### PR DESCRIPTION
Before
<img width="368" alt="Screenshot 2025-02-04 at 10 10 13" src="https://github.com/user-attachments/assets/9aa6bbd2-a012-4829-9100-2c560591e9f4" />

After
<img width="368" alt="Screenshot 2025-02-04 at 10 15 49" src="https://github.com/user-attachments/assets/710ff3de-f393-42aa-bfcc-47de847615cc" />
