### PR TITLE
Fix header slugs

### DIFF
--- a/src/guide/buy_btc.md
+++ b/src/guide/buy_btc.md
@@ -2,7 +2,10 @@
 
 The SDK also provides access to a Fiat on-ramp to purchase Bitcoin using Moonpay as a provider. It will generate a Bitcoin address and prepare a URL using the specified provider. The user then needs to open the URL and proceed with the provider flow to buy Bitcoin. Once the buy is completed, the provider will transfer the purchased amount to the Bitcoin address.
 
-## Checking the limits <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.fetch_onchain_limits">API docs</a>
+<h2 id="checking-the-limits">
+    <a class="header" href="#checking-the-limits">Checking the limits</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.fetch_onchain_limits">API docs</a>
+</h2>
 
 Fetch the current onchain limits to check the minimum and maximum allowed to purchase.
 
@@ -73,7 +76,10 @@ Fetch the current onchain limits to check the minimum and maximum allowed to pur
 </section>
 </custom-tabs>
 
-## Preparing to buy, checking fees <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_buy_bitcoin">API docs</a>
+<h2 id="preparing-to-buy-checking-fees">
+    <a class="header" href="#preparing-to-buy-checking-fees">Preparing to buy, checking fees</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_buy_bitcoin">API docs</a>
+</h2>
 
 Using the current onchain limits, select a provider and amount to purchase.
 
@@ -144,7 +150,10 @@ Using the current onchain limits, select a provider and amount to purchase.
 </section>
 </custom-tabs>
 
-## Generate the URL <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.buy_bitcoin">API docs</a>
+<h2 id="generate-the-url">
+    <a class="header" href="#generate-the-url">Generate the URL</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.buy_bitcoin">API docs</a>
+</h2>
 
 Generate a URL to the provider with a Bitcoin address to receive the purchase to. You can also pass in an optional redirect URL here that the provider redirects to after a successful purchase.
 

--- a/src/guide/connecting.md
+++ b/src/guide/connecting.md
@@ -1,4 +1,7 @@
-# Connecting <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.connect">API docs</a>
+<h1 id="connecting">
+    <a class="header" href="#connecting">Connecting</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.connect">API docs</a>
+</h1>
 
 The first step is to construct the SDK configuration. Among others, it sets the network you want to use, the SDK working directory and the Breez API key.
 
@@ -83,7 +86,10 @@ By default, the config working directory is set to the directory where the SDK i
 
 </div>
 
-# Disconnecting <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.disconnect">API docs</a>
+<h2 id="disconnecting">
+    <a class="header" href="#disconnecting">Disonnecting</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.disconnect">API docs</a>
+</h2>
 
 Once you are done using the SDK, you can call the `disconnect` method to free up the resources which are currently in use.
 

--- a/src/guide/events.md
+++ b/src/guide/events.md
@@ -2,7 +2,10 @@
 
 The SDK emits several events to provide the application with an up-to-date state of the wallet or ongoing payments.
 
-## Add event listener <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.add_event_listener">API docs</a>
+<h2 id="add-event-listener">
+    <a class="header" href="#add-event-listener">Add event listener</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.add_event_listener">API docs</a>
+</h2>
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>
@@ -74,7 +77,10 @@ The SDK emits several events to provide the application with an up-to-date state
 </section>
 </custom-tabs>
 
-## Remove event listener <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.remove_event_listener">API docs</a>
+<h2 id="remove-event-listener">
+    <a class="header" href="#remove-event-listener">Remove event listener</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.remove_event_listener">API docs</a>
+</h2>
 
 When you no longer need to listen to events, you can remove the listener.
 

--- a/src/guide/fiat_currencies.md
+++ b/src/guide/fiat_currencies.md
@@ -1,6 +1,9 @@
 # Supporting fiat currencies
 
-## List fiat currencies <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_fiat_currencies">API docs</a>
+<h2 id="list-fiat-currencies">
+    <a class="header" href="#list-fiat-currencies">List fiat currencies</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_fiat_currencies">API docs</a>
+</h2>
 
 You can get the full details of supported fiat currencies, such as symbols and localized names:
 
@@ -70,7 +73,10 @@ You can get the full details of supported fiat currencies, such as symbols and l
 </section>
 </custom-tabs>
 
-## Fetch fiat rates <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.fetch_fiat_rates">API docs</a>
+<h2 id="fetch-fiat-rates">
+    <a class="header" href="#fetch-fiat-rates">Fetch fiat rates</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.fetch_fiat_rates">API docs</a>
+</h2>
 
 To get the current BTC rate in the various supported fiat currencies:
 

--- a/src/guide/list_payments.md
+++ b/src/guide/list_payments.md
@@ -1,4 +1,7 @@
-# Listing payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_payments">API docs</a>
+<h1 id="listing-payments">
+    <a class="header" href="#listing-payments">Listing payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_payments">API docs</a>
+</h1>
 
 To view your payment history you can list all the sent and received payments made.
 
@@ -275,7 +278,10 @@ When listing payment you can also filter and page the list results, by:
 </section>
 </custom-tabs>
 
-## Get Payment <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_payment">API docs</a>
+<h2 id="get-payment">
+    <a class="header" href="#get-payment">Get Payment</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_payment">API docs</a>
+</h2>
 
 You can also retrieve a single Lightning payment using the invoice payment hash.
 

--- a/src/guide/lnurl_auth.md
+++ b/src/guide/lnurl_auth.md
@@ -1,4 +1,7 @@
-# LNURL-Auth <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_auth">API docs</a>
+<h1 id="lnurl-auth">
+    <a class="header" href="#lnurl-auth">LNURL-Auth</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_auth">API docs</a>
+</h1>
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/src/guide/lnurl_pay.md
+++ b/src/guide/lnurl_pay.md
@@ -1,6 +1,10 @@
 # LNURL-Pay
 
-## Preparing LNURL Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_lnurl_pay">API docs</a>
+<h2 id="preparing-lnurl-payments">
+    <a class="header" href="#preparing-lnurl-payments">Preparing LNURL Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_lnurl_pay">API docs</a>
+</h2>
+
 During the prepare step, the SDK ensures that the inputs are valid with respect to the LNURL-pay request,
 and also returns the relative fees related to the payment so they can be confirmed. If the LNURL-pay invoice
 includes a <a target="_blank" href="https://docs.boltz.exchange/v/api/magic-routing-hints">Magic Routing Hint</a> for a direct Liquid payment, the fees will reflect this.
@@ -71,7 +75,11 @@ includes a <a target="_blank" href="https://docs.boltz.exchange/v/api/magic-rout
 </section>
 </custom-tabs>
 
-## LNURL Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_pay">API docs</a>
+<h2 id="lnurl-payments">
+    <a class="header" href="#lnurl-payments">LNURL Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_pay">API docs</a>
+</h2>
+
 Once the payment has been prepared and the fees are accepted, all you have to do is pass the prepare response as an argument to the
 LNURL pay method.
 

--- a/src/guide/lnurl_withdraw.md
+++ b/src/guide/lnurl_withdraw.md
@@ -1,4 +1,7 @@
-# LNURL-Withdraw <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_withdraw">API docs</a>
+<h1 id="lnurl-withdraw">
+    <a class="header" href="#lnurl-withdraw">LNURL-Withdraw</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.lnurl_withdraw">API docs</a>
+</h1>
 
 <custom-tabs category="lang">
 <div slot="title">Rust</div>

--- a/src/guide/logging.md
+++ b/src/guide/logging.md
@@ -1,4 +1,7 @@
-# Adding logging <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.init_logging">API docs</a>
+<h1 id="adding-logging">
+    <a class="header" href="#adding-logging">Adding logging</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.init_logging">API docs</a>
+</h1>
 
 The SDK implements detailed logging via a streaming interface you can manage within your application. The log entries are split into several levels that you can filter and store as desired within your application, for example, by appending them to a log file.
 

--- a/src/guide/pay_onchain.md
+++ b/src/guide/pay_onchain.md
@@ -7,7 +7,11 @@ You can send funds from the Breez SDK wallet to an on-chain address as follows.
 Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
 </div>
 
-## Preparing Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_pay_onchain">API docs</a>
+<h2 id="preparing-payments">
+    <a class="header" href="#preparing-payments">Preparing Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_pay_onchain">API docs</a>
+</h2>
+
 When sending an onchain payment, the swap limits for sending onchain need to be first checked.
 
 <custom-tabs category="lang">
@@ -292,7 +296,10 @@ When you want send all funds from your wallet to another address.
 </section>
 </custom-tabs>
 
-## Sending Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.pay_onchain">API docs</a>
+<h2 id="sending-payments">
+    <a class="header" href="#sending-payments">Sending Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.pay_onchain">API docs</a>
+</h2>
 
 Once you checked the amounts and the fees are acceptable, you can continue with sending the payment.
 

--- a/src/guide/receive_payment.md
+++ b/src/guide/receive_payment.md
@@ -11,7 +11,11 @@ Once the SDK is initialized, you can directly begin receiving payments. The rece
 Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
 </div>
 
-## Preparing Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_receive_payment">API docs</a>
+<h2 id="preparing-payments">
+    <a class="header" href="#preparing-payments">Preparing Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_receive_payment">API docs</a>
+</h2>
+
 During the prepare step, the SDK ensures that the inputs are valid with respect to the specified payment method,
 and also returns the relative fees related to the payment so they can be confirmed.
 
@@ -246,7 +250,11 @@ To generate a BIP21 address, all you have to do is specify a payer amount.
 </section>
 </custom-tabs>
 
-## Receiving Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.receive_payment">API docs</a>
+<h2 id="receiving-payments">
+    <a class="header" href="#receiving-payments">Receiving Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.receive_payment">API docs</a>
+</h2>
+
 Once the payment has been prepared, all you have to do is pass the prepare response as an argument to the
 receive method, optionally specifying a description.
 

--- a/src/guide/refund_payment.md
+++ b/src/guide/refund_payment.md
@@ -2,7 +2,10 @@
 
 The SDK handles refunding of failed payments automatically except when receiving Bitcoin payments where the refund of a failed swap has to be managed manually.
 
-## List refundables <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_refundables">API docs</a>
+<h2 id="list-refundables">
+    <a class="header" href="#list-refundables">List refundables</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.list_refundables">API docs</a>
+</h2>
 
 In order to manually execute a Bitcoin refund, you need to supply an on-chain Bitcoin address to which the refunded amount will be sent. The following code will retrieve the refundable swaps:
 
@@ -72,7 +75,10 @@ In order to manually execute a Bitcoin refund, you need to supply an on-chain Bi
 </section>
 </custom-tabs>
 
-## Recommended fees <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.recommended_fees">API docs</a>
+<h2 id="recommended-fees">
+    <a class="header" href="#recommended-fees">Recommended fees</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.recommended_fees">API docs</a>
+</h2>
 
 To refund a swap, you need to set a fee rate for the Bitcoin transaction. You can get the Bitcoin mempool fee estimates from the SDK:
 
@@ -142,7 +148,10 @@ To refund a swap, you need to set a fee rate for the Bitcoin transaction. You ca
 </section>
 </custom-tabs>
 
-## Refund payment <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.refund">API docs</a>
+<h2 id="refund-payment">
+    <a class="header" href="#refund-payment">Refund payment</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.refund">API docs</a>
+</h2>
 
 Once you have a refundable swap, use the following code to execute a refund:
 

--- a/src/guide/rescanning_swaps.md
+++ b/src/guide/rescanning_swaps.md
@@ -1,4 +1,7 @@
-# Rescanning swaps <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.rescan_onchain_swaps">API docs</a>
+<h1 id="rescanning-swaps">
+    <a class="header" href="#rescanning-swaps">Rescanning swaps</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.rescan_onchain_swaps">API docs</a>
+</h1>
 
 The SDK continuously monitors any ongoing swap transactions until they are either completed or refunded. Once one of these outcomes occurs, the SDK ceases its monitoring activities, and users are advised against sending additional funds to the swap address. 
 

--- a/src/guide/self_signer.md
+++ b/src/guide/self_signer.md
@@ -1,4 +1,7 @@
-# Connecting an External Signer <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.connect_with_signer">API docs</a>
+<h2 id="connecting-an-external-signer">
+    <a class="header" href="#connecting-an-external-signer">Connecting an External Signer</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.connect_with_signer">API docs</a>
+</h2>
 
 By default, the SDK uses mnemonics to generate keys and sign transactions. However, in some cases, developers would prefer not to pass the seed key to the SDK. In these cases, you can provide an external signer that provides more control over key management and signing.
 

--- a/src/guide/send_payment.md
+++ b/src/guide/send_payment.md
@@ -9,7 +9,11 @@ Once the SDK is initialized, you can directly begin sending payments. The send p
 Consider implementing the <a href="/notifications/getting_started.md">Notification Plugin</a> when using the Breez SDK in a mobile application. By registering a webhook the application can receive notifications to process the payment in the background.
 </div>
 
-## Preparing Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_send_payment">API docs</a>
+<h2 id="preparing-payments">
+    <a class="header" href="#preparing-payments">Preparing Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_send_payment">API docs</a>
+</h2>
+
 During the prepare step, the SDK ensures that the inputs are valid with respect to the destination,
 and also returns the relative fees related to the payment so they can be confirmed. 
 
@@ -315,8 +319,11 @@ When you want send all funds from your wallet to another address.
 </section>
 </custom-tabs>
 
+<h2 id="sending-payments">
+    <a class="header" href="#sending-payments">Sending Payments</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.send_payment">API docs</a>
+</h2>
 
-## Sending Payments <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.send_payment">API docs</a>
 Once the payment has been prepared, all you have to do is pass the prepare response as an argument to the
 send method.
 

--- a/src/guide/wallet_state.md
+++ b/src/guide/wallet_state.md
@@ -1,4 +1,7 @@
-# Fetching the balance <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_info">API docs</a>
+<h1 id="fetching-the-balance">
+    <a class="header" href="#fetching-the-balance">Fetching the balance</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_info">API docs</a>
+</h1>
 
 Once connected, the balance can be retrieved at any time.
 

--- a/src/notifications/using_webhooks.md
+++ b/src/notifications/using_webhooks.md
@@ -1,6 +1,9 @@
 # Using Webhooks
 
-## Registering a Webhook <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.register_webhook">API docs</a>
+<h2 id="registering-a-webhook">
+    <a class="header" href="#registering-a-webhook">Registering a Webhook</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.register_webhook">API docs</a>
+</h2>
 
 Once your vendor [NDS is set up](setup_nds.md) and can accept POST requests from the SDK services, you can register the webhook URL within your main application by calling the register webhook API as follows
 
@@ -72,7 +75,10 @@ Once your vendor [NDS is set up](setup_nds.md) and can accept POST requests from
 
 When the NDS receives a POST request for the registered webhook URL, it will forward the request data via push notification to the applications Service Extension (iOS) or Foreground Service (Android) to be handled by the [Notification Plugin](setup_plugin.md).
 
-## Unregistering a Webhook <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.unregister_webhook">API docs</a>
+<h2 id="unregistering-a-webhook">
+    <a class="header" href="#unregistering-a-webhook">Unregistering a Webhook</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.unregister_webhook">API docs</a>
+</h2>
 
 When a webhook is no longer needed you can unregister the webhook as follows:
 


### PR DESCRIPTION
Adding `API docs` tags introduced a regression where `-api-docs` was also included in the header slug