### PR TITLE
Pre-release: Fix header slugs

### DIFF
--- a/src/guide/assets.md
+++ b/src/guide/assets.md
@@ -2,7 +2,10 @@
 
 The Liquid sidechain can also be used to send and receive other assets registered on the Liquid Network. Using the SDK you can send and receive these assets by using a Liquid payment with an additional asset ID. By default the SDK includes the metadata for [L-BTC and Tether USD](#default-asset-metadata). To include addition asset metadata, see [Adding asset metadata](#adding-asset-metadata).
 
-## Adding asset metadata <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/model/struct.Config.html#structfield.asset_metadata">API docs</a>
+<h2 id="adding-asset-metadata">
+    <a class="header" href="#adding-asset-metadata">Adding asset metadata</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/model/struct.Config.html#structfield.asset_metadata">API docs</a>
+</h2>
 
 You can add addition asset metadata to the SDK when you configure it on connect. In the example below we will add the [PEGx EUR](https://assets.blockstream.info/18729918ab4bca843656f08d4dd877bed6641fbd596a0a963abbf199cfeb3cec.json) asset. Once the asset metadata is added, it can be used as an asset to send and receive. 
 You can find the asset metadata for other assets in the Mainnet [Liquid Asset Registry](https://assets.blockstream.info/) ([Testnet](https://assets-testnet.blockstream.info/)).
@@ -86,7 +89,10 @@ You can find the asset metadata for other assets in the Mainnet [Liquid Asset Re
 | Testnet Bitcoin | BTC | 144c654344aa716d6f3abcc1ca90e5641e4e2a7f633bc09fe3baf64585819a49 | 8 |
 | Testnet Tether USD | USDt | b612eb46313a2cd6ebabd8b7a8eed5696e29898b87a43bff41c94f51acef9d73 | 8 |
 
-## Fetching the asset balances <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_info">API docs</a>
+<h2 id="fetching-the-asset-balances">
+    <a class="header" href="#fetching-the-asset-balances">Fetching the asset balances</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.get_info">API docs</a>
+</h2>
 
 Once connected, the asset balances can be retreived.
 
@@ -156,7 +162,10 @@ Once connected, the asset balances can be retreived.
 </section>
 </custom-tabs>
 
-## Receiving a non-Bitcoin asset <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_receive_payment">API docs</a>
+<h2 id="receiving-a-non-bitcoin-asset">
+    <a class="header" href="#receiving-a-non-bitcoin-asset">Receiving a non-Bitcoin asset</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_receive_payment">API docs</a>
+</h2>
 
 When receiving an asset via Liquid, we can generate a BIP21 URI with information regarding the payment of a specific asset. The amount to receive is optional and omitting it will result in an amountless BIP21 URI. 
 
@@ -229,7 +238,10 @@ In the example below we are using the [Mainnet Tether USD](https://assets.blocks
 </custom-tabs>
 <br/>
 
-## Sending a non-Bitcoin asset <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_send_payment">API docs</a>
+<h2 id="sending-a-non-bitcoin-asset">
+    <a class="header" href="#sending-a-non-bitcoin-asset">Sending a non-Bitcoin asset</a>
+    <a class="tag" target="_blank" href="https://breez.github.io/breez-sdk-liquid/breez_sdk_liquid/sdk/struct.LiquidSdk.html#method.prepare_send_payment">API docs</a>
+</h2>
 
 When sending an asset via Liquid, a BIP21 URI or Liquid address can be used as the destination. If a Liquid address is used, the optional prepare request amount **must** be set. If a BIP21 URI is used, either the BIP21 URI amount or optional prepare request amount **must** be set. When both amounts are set, the SDK will prioritize the **request amount** over the BIP21 amount. 
 


### PR DESCRIPTION
Adding `API docs` tags introduced a regression where `-api-docs` was also included in the header slug