### PR TITLE
Fix Python snippet callbacks and logs

### DIFF
--- a/snippets/python/src/getting_started.py
+++ b/snippets/python/src/getting_started.py
@@ -35,8 +35,8 @@ def fetch_balance(sdk: BindingLiquidSdk):
 
 # ANCHOR: logging
 class SdkLogger(Logger):
-    def log(log_entry: LogEntry):
-        logging.debug("Received log [", log_entry.level, "]: ", log_entry.line)
+    def log(self, log_entry: LogEntry):
+        logging.debug(f"Received log [{log_entry.level}]: {log_entry.line}")
 
 def set_logger(logger: SdkLogger):
     try:
@@ -48,8 +48,8 @@ def set_logger(logger: SdkLogger):
 
 # ANCHOR: add-event-listener
 class SdkListener(EventListener):
-    def on_event(sdk_event: SdkEvent):
-        logging.debug("Received event ", sdk_event)
+    def on_event(self, sdk_event: SdkEvent):
+        logging.debug(f"Received event {sdk_event}")
 
 def add_event_listener(sdk: BindingLiquidSdk, listener: SdkListener):
     try:

--- a/snippets/python/src/receive_payment.py
+++ b/snippets/python/src/receive_payment.py
@@ -7,8 +7,8 @@ def prepare_receive_lightning(sdk: BindingLiquidSdk):
     try:
         # Fetch the lightning Receive limits
         current_limits = sdk.fetch_lightning_limits()
-        logging.debug("Minimum amount allowed to deposit in sats ", current_limits.receive.min_sat)
-        logging.debug("Maximum amount allowed to deposit in sats ", current_limits.receive.max_sat)
+        logging.debug(f"Minimum amount allowed to deposit in sats {current_limits.receive.min_sat}")
+        logging.debug(f"Maximum amount allowed to deposit in sats {current_limits.receive.max_sat}")
 
         # Set the invoice amount you wish the payer to send, which should be within the above limits
         optional_amount = ReceiveAmount.BITCOIN(5_000)
@@ -17,7 +17,7 @@ def prepare_receive_lightning(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", receive_fees_sat, " sats")
+        logging.debug(f"Fees: {receive_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -29,8 +29,8 @@ def prepare_receive_onchain(sdk: BindingLiquidSdk):
     try:
         # Fetch the onchain Receive limits
         current_limits = sdk.fetch_onchain_limits()
-        logging.debug("Minimum amount allowed to deposit in sats ", current_limits.receive.min_sat)
-        logging.debug("Maximum amount allowed to deposit in sats ", current_limits.receive.max_sat)
+        logging.debug(f"Minimum amount allowed to deposit in sats {current_limits.receive.min_sat}")
+        logging.debug(f"Maximum amount allowed to deposit in sats {current_limits.receive.max_sat}")
 
         # Set the onchain amount you wish the payer to send, which should be within the above limits
         optional_amount = ReceiveAmount.BITCOIN(5_000)
@@ -39,7 +39,7 @@ def prepare_receive_onchain(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", receive_fees_sat, " sats")
+        logging.debug(f"Fees: {receive_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -58,7 +58,7 @@ def prepare_receive_liquid(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Receive Payment
         receive_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", receive_fees_sat, " sats")
+        logging.debug(f"Fees: {receive_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)

--- a/snippets/python/src/send_payment.py
+++ b/snippets/python/src/send_payment.py
@@ -11,7 +11,7 @@ def prepare_send_payment_lightning_bolt11(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", send_fees_sat, " sats")
+        logging.debug(f"Fees: {send_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -43,7 +43,7 @@ def prepare_send_payment_liquid(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", send_fees_sat, " sats")
+        logging.debug(f"Fees: {send_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)
@@ -60,7 +60,7 @@ def prepare_send_payment_liquid_drain(sdk: BindingLiquidSdk):
 
         # If the fees are acceptable, continue to create the Send Payment
         send_fees_sat = prepare_response.fees_sat
-        logging.debug("Fees: ", send_fees_sat, " sats")
+        logging.debug(f"Fees: {send_fees_sat} sats")
         return prepare_response
     except Exception as error:
         logging.error(error)


### PR DESCRIPTION
This PR addresses 2 issues with the Python snippets:

- adds a missing `self` parameter to the Python snippet callbacks 
- Uses f-strings for logging where they weren't yet used. Comma-separated values don't work because `logging` methods behave differently from `print()`.