### PR TITLE
fix: Use `isinstance` for checking parsed input type

### DIFF
--- a/snippets/python/src/parsing_inputs.py
+++ b/snippets/python/src/parsing_inputs.py
@@ -7,16 +7,16 @@ def parse_input(sdk: BindingLiquidSdk):
 
     try:
         parsed_input = sdk.parse(input)
-        if parsed_input.type == InputType.BITCOIN_ADDRESS:
+        if isinstance(parsed_input, InputType.BITCOIN_ADDRESS):
             logging.debug(f"Input is Bitcoin address {parsed_input.address.address}")
-        elif parsed_input.type == InputType.BOLT11:
+        elif isinstance(parsed_input, InputType.BOLT11):
             amount = "unknown"
             if parsed_input.invoice.amount_msat:
                 amount = str(parsed_input.invoice.amount_msat)
             logging.debug(f"Input is BOLT11 invoice for {amount} msats")
-        elif parsed_input.type == InputType.LN_URL_PAY:
+        elif isinstance(parsed_input, InputType.LN_URL_PAY):
             logging.debug(f"Input is LNURL-Pay/Lightning address accepting min/max {parsed_input.data.min_sendable}/{parsed_input.data.max_sendable} msats - BIP353 was used: {parsed_input.bip353_address is not None}")
-        elif parsed_input.type == InputType.LN_URL_WITHDRAW:
+        elif isinstance(parsed_input, InputType.LN_URL_WITHDRAW):
             logging.debug(f"Input is LNURL-Withdraw for min/max {parsed_input.data.min_withdrawable}/{parsed_input.data.max_withdrawable} msats")
         # Other input types are available
     except Exception as error:


### PR DESCRIPTION
The parse snippet was implemented as if the InputType was an enum, but it's a class with subclasses for each input type.