### PR TITLE
Add mnemonic generation and handling in CLI

### DIFF
--- a/examples/python/cli/cli.py
+++ b/examples/python/cli/cli.py
@@ -44,19 +44,27 @@ class Sdk:
     def is_synced(self):
         return self.listener.is_synced()
     
+    def generate_mnemonic(self):
+        mnemo = Mnemonic("english")
+        words = mnemo.generate(strength=128)
+        return words
+
     def read_mnemonic(self):
         if exists('phrase'):
             with open('phrase') as f:
                 mnemonic = f.readline()
+                if not mnemonic:
+                    mnemonic = self.generate_mnemonic()
+                    with open('phrase', 'w') as f:
+                        f.write(mnemonic)
                 f.close()
                 return mnemonic
         else:
             with open('phrase', 'w') as f:
-                mnemo = Mnemonic("english")
-                words = mnemo.generate(strength=128)
-                f.write(words)
+                mnemonic = self.generate_mnemonic()
+                f.write(mnemonic)
                 f.close()
-                return words
+                return mnemonic
 
 
 class SdkLogListener(breez_sdk_liquid.Logger):


### PR DESCRIPTION
- Introduced a new method to generate a mnemonic phrase if none exists.
- Updated the read_mnemonic method to ensure a mnemonic is always available, either by reading from a file (even empty one) or generating a new one.
- fix to issue #93 
