### PR TITLE
Add node.js min supported version

### DIFF
--- a/src/guide/install.md
+++ b/src/guide/install.md
@@ -60,6 +60,8 @@ dependencies {
 
 We recommend using the official npm package: [@breeztech/breez-sdk-liquid](https://www.npmjs.com/package/@breeztech/breez-sdk-liquid).
 
+> **Note:** If using Node.js, the minimum supported version is v22.
+
 ```console
 npm install @breeztech/breez-sdk-liquid
 ```


### PR DESCRIPTION
Our implementation relies on the websocket client implementation introduced in node v22: https://nodejs.org/en/blog/announcements/v22-release-announce#websocket