### PR TITLE
Fix NDS example URL

### DIFF
--- a/examples/breez-nodeless-llms/breez-nodeless-python-llms.md
+++ b/examples/breez-nodeless-llms/breez-nodeless-python-llms.md
@@ -857,7 +857,7 @@ def list_payments_details_destination(sdk: BindingLiquidSdk):
 ```python
 def register_webhook(sdk: BindingLiquidSdk):
     try:
-        sdk.register_webhook("https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>")
+        sdk.register_webhook("https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>")
     except Exception as error:
         logging.error(error)
         raise

--- a/examples/breez-nodeless-llms/breez-nodeless-reactnative-llms.md
+++ b/examples/breez-nodeless-llms/breez-nodeless-reactnative-llms.md
@@ -238,7 +238,7 @@ import { registerWebhook, unregisterWebhook } from '@breeztech/react-native-bree
 
 const registerWebhookExample = async () => {
   try {
-    await registerWebhook('https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>')
+    await registerWebhook('https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>')
   } catch (err) {
     console.error(err)
   }

--- a/examples/breez-nodeless-llms/breez-nodeless-rust-llms.md
+++ b/examples/breez-nodeless-llms/breez-nodeless-rust-llms.md
@@ -885,7 +885,7 @@ async fn list_payments_details_destination(sdk: Arc<LiquidSdk>) -> Result<Vec<Pa
 ```rust
 async fn register_webhook(sdk: Arc<LiquidSdk>) -> Result<()> {
     sdk.register_webhook(
-        "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>".to_string(),
+        "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>".to_string(),
     )
     .await?;
     

--- a/examples/breez-nodeless-llms/breez-nodeless-wasm-llms.md
+++ b/examples/breez-nodeless-llms/breez-nodeless-wasm-llms.md
@@ -863,7 +863,7 @@ const listPaymentsDetailsDestination = async (sdk) => {
 ```typescript
 const registerWebhook = async (sdk) => {
   try {
-    await sdk.registerWebhook('https://your-nds-service.com/notify?platform=web&token=<PUSH_TOKEN>');
+    await sdk.registerWebhook('https://your-nds-service.com/api/v1/notify?platform=web&token=<PUSH_TOKEN>');
   } catch (err) {
     console.error(err);
   }

--- a/snippets/csharp/Webhook.cs
+++ b/snippets/csharp/Webhook.cs
@@ -7,7 +7,7 @@ public class ServiceStatusSnippets
         // ANCHOR: register-webook
         try
         {
-            sdk.RegisterWebhook("https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");
+            sdk.RegisterWebhook("https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>");
         }
         catch (Exception)
         {

--- a/snippets/dart_snippets/lib/webhook.dart
+++ b/snippets/dart_snippets/lib/webhook.dart
@@ -3,7 +3,7 @@ import 'package:dart_snippets/sdk_instance.dart';
 Future<void> registerWebhook() async {
   // ANCHOR: register-webook
   await breezSDKLiquid.instance!
-      .registerWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>");
+      .registerWebhook(webhookUrl: "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>");
   // ANCHOR_END: register-webook
 }
 

--- a/snippets/go/webhook.go
+++ b/snippets/go/webhook.go
@@ -8,7 +8,7 @@ import (
 
 func RegisterWebhook(sdk *breez_sdk_liquid.BindingLiquidSdk) {
 	// ANCHOR: register-webook
-	if err := sdk.RegisterWebhook("https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>"); err != nil {
+	if err := sdk.RegisterWebhook("https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>"); err != nil {
 		log.Printf("Webhook register failed: %v", err)
 	}
 	// ANCHOR_END: register-webook

--- a/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Webhook.kt
+++ b/snippets/kotlin_mpp_lib/shared/src/commonMain/kotlin/com/example/kotlinmpplib/Webhook.kt
@@ -5,7 +5,7 @@ class Webhooks {
     fun registerWebhook(sdk: BindingLiquidSdk) {
         // ANCHOR: register-webook
         try {
-            sdk.registerWebhook("https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>")
+            sdk.registerWebhook("https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>")
         } catch (e: Exception) {
             // Handle error
         }

--- a/snippets/python/src/webhook.py
+++ b/snippets/python/src/webhook.py
@@ -5,7 +5,7 @@ from breez_sdk_liquid import BindingLiquidSdk
 def register_webhook(sdk: BindingLiquidSdk):
     # ANCHOR: register-webook
     try:
-        sdk.register_webhook("https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>")
+        sdk.register_webhook("https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>")
     except Exception as error:
         logging.error(error)
         raise

--- a/snippets/react-native/webhook.ts
+++ b/snippets/react-native/webhook.ts
@@ -3,7 +3,7 @@ import { registerWebhook, unregisterWebhook } from '@breeztech/react-native-bree
 const _registerWebhook = async () => {
   // ANCHOR: register-webook
   try {
-    await registerWebhook('https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>')
+    await registerWebhook('https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>')
   } catch (err) {
     console.error(err)
   }

--- a/snippets/rust/src/webhook.rs
+++ b/snippets/rust/src/webhook.rs
@@ -6,7 +6,7 @@ use breez_sdk_liquid::prelude::*;
 async fn register_webhook(sdk: Arc<LiquidSdk>) -> Result<()> {
     // ANCHOR: register-webook
     sdk.register_webhook(
-        "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>".to_string(),
+        "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>".to_string(),
     )
     .await?;
     // ANCHOR_END: register-webook

--- a/snippets/swift/BreezSDKExamples/Sources/Webhook.swift
+++ b/snippets/swift/BreezSDKExamples/Sources/Webhook.swift
@@ -9,7 +9,7 @@ import BreezSDKLiquid
 
 func registerWebhook(sdk: BindingLiquidSdk) throws {
     // ANCHOR: register-webook
-    try sdk.registerWebhook(webhookUrl: "https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>")  
+    try sdk.registerWebhook(webhookUrl: "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>")  
     // ANCHOR_END: register-webook
 }
 

--- a/snippets/wasm/webhook.ts
+++ b/snippets/wasm/webhook.ts
@@ -3,7 +3,7 @@ import { type BindingLiquidSdk } from '@breeztech/breez-sdk-liquid'
 const _registerWebhook = async (sdk: BindingLiquidSdk) => {
   // ANCHOR: register-webook
   try {
-    await sdk.registerWebhook('https://your-nds-service.com/notify?platform=ios&token=<PUSH_TOKEN>')
+    await sdk.registerWebhook('https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>')
   } catch (err) {
     console.error(err)
   }

--- a/src/notifications/setup_nds.md
+++ b/src/notifications/setup_nds.md
@@ -14,14 +14,10 @@ Receiving push notifications involves using an Notification Delivery Service (ND
 
 The need to run your own NDS is because it's configured to send push notifications to your application users and therefore should be configured with the required keys and certificates. You can use our [reference NDS implementation](https://github.com/breez/notify) as a starting point or as is. Our implementation of the NDS expects URLs in the following format:
 ```
-https://your-nds-service.com/notify?platform=<ios|android>&token=[PUSH_TOKEN]
+https://your-nds-service.com/api/v1/notify?platform=<ios|android>&token=[PUSH_TOKEN]
 ```
-  
-
 
 This is the same format used when [using webhooks](using_webhooks.md) in the SDK, replacing the `PUSH_TOKEN` with the mobile push token. Once the NDS receives such a request it will send a push notification to the corresponding device.
 
 ## Mobile push token
-Ensure that your mobile application is set up to receive push notifications and can generate a push token, which uniquely identifies the device for push notifications.
-* For iOS, use [Apple Push Notification Service (APNs)](https://developer.apple.com/documentation/usernotifications/registering_your_app_with_apns) to get the token.
-* For Android, use [Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/manage-tokens) to obtain the token.
+Ensure that your mobile application is set up to receive push notifications and can generate a push token, which uniquely identifies the device for push notifications. Our [reference NDS implementation](https://github.com/breez/notify) uses [Firebase Cloud Messaging (FCM)](https://firebase.google.com/docs/cloud-messaging/manage-tokens) to deliver push notifications, so your application should use Firebase to obtain the `PUSH_TOKEN`.


### PR DESCRIPTION
This PR:
- Fixes the NDS webhook URLs for the reference implementation
- Clarifies the FCM token should be used for both iOS and Android