### PR TITLE
docs: update Dart snippets for flutter_breez_liquid after Cargokit migration

### DIFF
--- a/snippets/dart_snippets/bin/dart_snippets.dart
+++ b/snippets/dart_snippets/bin/dart_snippets.dart
@@ -2,5 +2,5 @@ import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 
 void main() async {
   // Initialize library
-  await liquid_sdk.initialize();
+  await liquid_sdk.FlutterBreezLiquid.init();
 }

--- a/snippets/dart_snippets/lib/buy_btc.dart
+++ b/snippets/dart_snippets/lib/buy_btc.dart
@@ -13,8 +13,11 @@ Future<OnchainPaymentLimitsResponse> fetchOnchainLimits() async {
 
 Future<PrepareBuyBitcoinResponse> prepareBuyBitcoin(OnchainPaymentLimitsResponse currentLimits) async {
   // ANCHOR: prepare-buy-btc
-  PrepareBuyBitcoinRequest req =
-      PrepareBuyBitcoinRequest(provider: BuyBitcoinProvider.moonpay, amountSat: currentLimits.receive.minSat);
+  PrepareBuyBitcoinRequest req = PrepareBuyBitcoinRequest(
+    provider: BuyBitcoinProvider.moonpay,
+    amountSat: currentLimits.receive.minSat,
+  );
+
   PrepareBuyBitcoinResponse prepareRes = await breezSDKLiquid.instance!.prepareBuyBitcoin(req: req);
 
   // Check the fees are acceptable before proceeding
@@ -27,6 +30,7 @@ Future<PrepareBuyBitcoinResponse> prepareBuyBitcoin(OnchainPaymentLimitsResponse
 Future<String> buyBitcoin(PrepareBuyBitcoinResponse prepareResponse) async {
   // ANCHOR: buy-btc
   BuyBitcoinRequest req = BuyBitcoinRequest(prepareResponse: prepareResponse);
+
   String url = await breezSDKLiquid.instance!.buyBitcoin(req: req);
   // ANCHOR_END: buy-btc
   return url;

--- a/snippets/dart_snippets/lib/configuration.dart
+++ b/snippets/dart_snippets/lib/configuration.dart
@@ -48,7 +48,10 @@ Future<void> configureParsers() async {
 Future<void> configureMagicRoutingHints() async {
   // ANCHOR: configure-magic-routing-hints
   // Create the default config
-  Config config = defaultConfig(network: LiquidNetwork.mainnet, breezApiKey: "<your-Breez-API-key>");
+  Config config = defaultConfig(
+    network: LiquidNetwork.mainnet,
+    breezApiKey: "<your-Breez-API-key>",
+  );
 
   // Configure magic routing hints
   config = config.copyWith(

--- a/snippets/dart_snippets/lib/getting_started.dart
+++ b/snippets/dart_snippets/lib/getting_started.dart
@@ -1,6 +1,8 @@
 import 'dart:async';
 
 import 'package:dart_snippets/sdk_instance.dart';
+import 'package:flutter/foundation.dart';
+import 'package:flutter/services.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart';
 
 Future<void> initializeSDK() async {
@@ -58,10 +60,16 @@ class BreezSDKLiquid {
   //
   // Call once on your Dart entrypoint file, e.g.; `lib/main.dart`.
   void initializeLogStream() {
-    _breezLogStream ??= breezLogStream().asBroadcastStream();
+    if (defaultTargetPlatform == TargetPlatform.android) {
+      _breezLogStream ??= const EventChannel('breez_sdk_liquid_logs').receiveBroadcastStream().map(
+            (dynamic log) => LogEntry(line: log['line'], level: log['level']),
+          );
+    } else {
+      _breezLogStream ??= breezLogStream().asBroadcastStream();
+    }
   }
 
-  final _logStreamController = StreamController<LogEntry>.broadcast();
+  final StreamController<LogEntry> _logStreamController = StreamController<LogEntry>.broadcast();
   Stream<LogEntry> get logStream => _logStreamController.stream;
 
   // Subscribe to the log stream
@@ -86,7 +94,7 @@ class BreezSDKLiquid {
   // Initializes SDK event stream.
   //
   // Call once on your Dart entrypoint file, e.g.; `lib/main.dart`.
-  void initializeEventsStream(BindingLiquidSdk sdk) {
+  void initializeEventsStream(BreezSdkLiquid sdk) {
     _breezEventStream ??= sdk.addEventListener().asBroadcastStream();
   }
 

--- a/snippets/dart_snippets/lib/list_payments.dart
+++ b/snippets/dart_snippets/lib/list_payments.dart
@@ -17,6 +17,7 @@ Future<(Payment?, Payment?)> getPayment() async {
 Future<List<Payment>> listPayments() async {
   // ANCHOR: list-payments
   ListPaymentsRequest req = ListPaymentsRequest();
+
   List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
   // ANCHOR_END: list-payments
   return paymentsList;
@@ -31,6 +32,7 @@ Future<List<Payment>> listPaymentsFiltered() async {
     offset: 0,
     limit: 50,
   );
+
   List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
   // ANCHOR_END: list-payments-filtered
   return paymentsList;
@@ -42,6 +44,7 @@ Future<List<Payment>> listPaymentsDetailsAddress() async {
   ListPaymentsRequest req = ListPaymentsRequest(
     details: ListPaymentDetails_Bitcoin(address: address),
   );
+
   List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
   // ANCHOR_END: list-payments-details-address
   return paymentsList;
@@ -53,6 +56,7 @@ Future<List<Payment>> listPaymentsDetailsDestination() async {
   ListPaymentsRequest req = ListPaymentsRequest(
     details: ListPaymentDetails_Liquid(destination: destination),
   );
+
   List<Payment> paymentsList = await breezSDKLiquid.instance!.listPayments(req: req);
   // ANCHOR_END: list-payments-details-destination
   return paymentsList;

--- a/snippets/dart_snippets/lib/lnurl_pay.dart
+++ b/snippets/dart_snippets/lib/lnurl_pay.dart
@@ -42,6 +42,7 @@ Future<void> prepareLnurlPayDrain({required LnUrlPayRequestData data}) async {
     comment: optionalComment,
     validateSuccessActionUrl: optionalValidateSuccessActionUrl,
   );
+
   PrepareLnUrlPayResponse prepareResponse = await breezSDKLiquid.instance!.prepareLnurlPay(req: req);
   // ANCHOR_END: prepare-lnurl-pay-drain
   print(prepareResponse);
@@ -49,8 +50,10 @@ Future<void> prepareLnurlPayDrain({required LnUrlPayRequestData data}) async {
 
 Future<void> lnurlPay({required PrepareLnUrlPayResponse prepareResponse}) async {
   // ANCHOR: lnurl-pay
+  LnUrlPayRequest lnUrlPayRequest = LnUrlPayRequest(prepareResponse: prepareResponse);
+
   LnUrlPayResult result = await breezSDKLiquid.instance!.lnurlPay(
-    req: LnUrlPayRequest(prepareResponse: prepareResponse),
+    req: lnUrlPayRequest,
   );
   // ANCHOR_END: lnurl-pay
   print(result);

--- a/snippets/dart_snippets/lib/lnurl_withdraw.dart
+++ b/snippets/dart_snippets/lib/lnurl_withdraw.dart
@@ -16,6 +16,7 @@ Future<void> lnurlWithdraw() async {
       amountMsat: amountMsat,
       description: "<description>",
     );
+
     LnUrlWithdrawResult result = await breezSDKLiquid.instance!.lnurlWithdraw(req: req);
     print(result.data);
   }

--- a/snippets/dart_snippets/lib/messages.dart
+++ b/snippets/dart_snippets/lib/messages.dart
@@ -6,6 +6,7 @@ Future<SignMessageResponse> signMessage() async {
   SignMessageRequest signMessageRequest = SignMessageRequest(
     message: "<message to sign>",
   );
+
   SignMessageResponse signMessageResponse = breezSDKLiquid.instance!.signMessage(
     req: signMessageRequest,
   );
@@ -29,6 +30,7 @@ Future<CheckMessageResponse> checkMessage() async {
     pubkey: "<pubkey of signer>",
     signature: "<message signature>",
   );
+
   CheckMessageResponse checkMessageResponse = breezSDKLiquid.instance!.checkMessage(
     req: checkMessageRequest,
   );

--- a/snippets/dart_snippets/lib/notification_plugin.dart
+++ b/snippets/dart_snippets/lib/notification_plugin.dart
@@ -27,7 +27,7 @@ Future<void> initSdk() async {
 
   // Create the default config, providing your Breez API key
   Config config = defaultConfig(network: LiquidNetwork.mainnet, breezApiKey: "<your-Breez-API-key>");
-  
+
   // Set the working directory to the app group path
   config = config.copyWith(workingDir: await getWorkingDir());
 

--- a/snippets/dart_snippets/lib/parsing_inputs.dart
+++ b/snippets/dart_snippets/lib/parsing_inputs.dart
@@ -13,13 +13,17 @@ Future<void> parseInput() async {
         inputType.invoice.amountMsat != null ? inputType.invoice.amountMsat.toString() : "unknown";
     print("Input is BOLT11 invoice for $amountStr msats");
   } else if (inputType is InputType_Bolt12Offer) {
-    print("Input is BOLT12 offer for min ${inputType.offer.minAmount} msats - BIP353 was used: ${inputType.bip353Address != null}");
+    print(
+      "Input is BOLT12 offer for min ${inputType.offer.minAmount} msats - BIP353 was used: ${inputType.bip353Address != null}",
+    );
   } else if (inputType is InputType_LnUrlPay) {
     print(
-        "Input is LNURL-Pay/Lightning address accepting min/max ${inputType.data.minSendable}/${inputType.data.maxSendable} msats - BIP353 was used: ${inputType.bip353Address != null}");
+      "Input is LNURL-Pay/Lightning address accepting min/max ${inputType.data.minSendable}/${inputType.data.maxSendable} msats - BIP353 was used: ${inputType.bip353Address != null}",
+    );
   } else if (inputType is InputType_LnUrlWithdraw) {
     print(
-        "Input is LNURL-Withdraw for min/max ${inputType.data.minWithdrawable}/${inputType.data.maxWithdrawable} msats");
+      "Input is LNURL-Withdraw for min/max ${inputType.data.minWithdrawable}/${inputType.data.maxWithdrawable} msats",
+    );
   } else {
     // Other input types are available
   }

--- a/snippets/dart_snippets/lib/pay_onchain.dart
+++ b/snippets/dart_snippets/lib/pay_onchain.dart
@@ -15,6 +15,7 @@ Future<PreparePayOnchainResponse> preparePayOnchain() async {
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
     amount: PayAmount_Bitcoin(receiverAmountSat: 5000 as BigInt),
   );
+
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(
     req: preparePayOnchainRequest,
   );
@@ -31,6 +32,7 @@ Future<PreparePayOnchainResponse> preparePayOnchainDrain() async {
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
     amount: PayAmount_Drain(),
   );
+
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(
     req: preparePayOnchainRequest,
   );
@@ -45,11 +47,11 @@ Future<PreparePayOnchainResponse> preparePayOnchainDrain() async {
 Future<PreparePayOnchainResponse> preparePayOnchainFeeRate() async {
   // ANCHOR: prepare-pay-onchain-fee-rate
   int optionalSatPerVbyte = 21;
-
   PreparePayOnchainRequest preparePayOnchainRequest = PreparePayOnchainRequest(
     amount: PayAmount_Bitcoin(receiverAmountSat: 5000 as BigInt),
     feeRateSatPerVbyte: optionalSatPerVbyte,
   );
+
   PreparePayOnchainResponse prepareRes = await breezSDKLiquid.instance!.preparePayOnchain(
     req: preparePayOnchainRequest,
   );
@@ -68,11 +70,11 @@ Future<SendPaymentResponse> startReverseSwap({
 }) async {
   // ANCHOR: start-reverse-swap
   String destinationAddress = "bc1..";
-
   PayOnchainRequest req = PayOnchainRequest(
     address: destinationAddress,
     prepareResponse: prepareRes,
   );
+
   SendPaymentResponse res = await breezSDKLiquid.instance!.payOnchain(req: req);
   // ANCHOR_END: start-reverse-swap
   return res;

--- a/snippets/dart_snippets/lib/receive_payment.dart
+++ b/snippets/dart_snippets/lib/receive_payment.dart
@@ -11,11 +11,13 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLightning() async {
 
   // Create an invoice and set the amount you wish the payer to send
   ReceiveAmount_Bitcoin optionalAmount = ReceiveAmount_Bitcoin(payerAmountSat: 5000 as BigInt);
+  PrepareReceiveRequest prepareReceiveRequest = PrepareReceiveRequest(
+    paymentMethod: PaymentMethod.bolt11Invoice,
+    amount: optionalAmount,
+  );
+
   PrepareReceiveResponse prepareResponse = await breezSDKLiquid.instance!.prepareReceivePayment(
-    req: PrepareReceiveRequest(
-      paymentMethod: PaymentMethod.bolt11Invoice,
-      amount: optionalAmount,
-    ),
+    req: prepareReceiveRequest,
   );
 
   // If the fees are acceptable, continue to create the Receive Payment
@@ -27,8 +29,12 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLightning() async {
 
 Future<PrepareReceiveResponse> prepareReceivePaymentLightningBolt12() async {
   // ANCHOR: prepare-receive-payment-lightning-bolt12
+  PrepareReceiveRequest prepareReceiveRequest = PrepareReceiveRequest(
+    paymentMethod: PaymentMethod.bolt12Offer,
+  );
+
   PrepareReceiveResponse prepareResponse = await breezSDKLiquid.instance!.prepareReceivePayment(
-    req: PrepareReceiveRequest(paymentMethod: PaymentMethod.bolt12Offer),
+    req: prepareReceiveRequest,
   );
 
   // If the fees are acceptable, continue to create the Receive Payment
@@ -48,11 +54,13 @@ Future<PrepareReceiveResponse> prepareReceivePaymentOnchain() async {
 
   // Or create a cross-chain transfer (Liquid to Bitcoin) via chain swap
   ReceiveAmount_Bitcoin optionalAmount = ReceiveAmount_Bitcoin(payerAmountSat: 5000 as BigInt);
+  PrepareReceiveRequest prepareReceiveRequest = PrepareReceiveRequest(
+    paymentMethod: PaymentMethod.bitcoinAddress,
+    amount: optionalAmount,
+  );
+
   PrepareReceiveResponse prepareResponse = await breezSDKLiquid.instance!.prepareReceivePayment(
-    req: PrepareReceiveRequest(
-      paymentMethod: PaymentMethod.bitcoinAddress,
-      amount: optionalAmount,
-    ),
+    req: prepareReceiveRequest,
   );
 
   // If the fees are acceptable, continue to create the Receive Payment
@@ -68,11 +76,13 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLiquid() async {
   // There are no limits, but the payer amount should be greater than broadcast fees when specified
   // Note: Not setting the amount will generate a plain Liquid address
   ReceiveAmount_Bitcoin optionalAmount = ReceiveAmount_Bitcoin(payerAmountSat: 5000 as BigInt);
+  PrepareReceiveRequest prepareReceiveRequest = PrepareReceiveRequest(
+    paymentMethod: PaymentMethod.liquidAddress,
+    amount: optionalAmount,
+  );
+
   PrepareReceiveResponse prepareResponse = await breezSDKLiquid.instance!.prepareReceivePayment(
-    req: PrepareReceiveRequest(
-      paymentMethod: PaymentMethod.liquidAddress,
-      amount: optionalAmount,
-    ),
+    req: prepareReceiveRequest,
   );
 
   // If the fees are acceptable, continue to create the Receive Payment
@@ -85,11 +95,13 @@ Future<PrepareReceiveResponse> prepareReceivePaymentLiquid() async {
 Future<ReceivePaymentResponse> receivePayment(PrepareReceiveResponse prepareResponse) async {
   // ANCHOR: receive-payment
   String optionalDescription = "<description>";
+  ReceivePaymentRequest receivePaymentRequest = ReceivePaymentRequest(
+    description: optionalDescription,
+    prepareResponse: prepareResponse,
+  );
+
   ReceivePaymentResponse res = await breezSDKLiquid.instance!.receivePayment(
-    req: ReceivePaymentRequest(
-      description: optionalDescription,
-      prepareResponse: prepareResponse,
-    ),
+    req: receivePaymentRequest,
   );
 
   String destination = res.destination;

--- a/snippets/dart_snippets/lib/sdk_instance.dart
+++ b/snippets/dart_snippets/lib/sdk_instance.dart
@@ -1,6 +1,5 @@
 import 'dart:async';
 
-import 'package:breez_liquid/breez_liquid.dart';
 import 'package:flutter_breez_liquid/flutter_breez_liquid.dart' as liquid_sdk;
 import 'package:rxdart/rxdart.dart';
 
@@ -13,9 +12,9 @@ class BreezSDKLiquid {
     initializeLogStream();
   }
 
-  liquid_sdk.BindingLiquidSdk? _instance;
+  liquid_sdk.BreezSdkLiquid? _instance;
 
-  liquid_sdk.BindingLiquidSdk? get instance => _instance;
+  liquid_sdk.BreezSdkLiquid? get instance => _instance;
 
   Future<void> connect({
     required liquid_sdk.ConnectRequest req,
@@ -41,19 +40,19 @@ class BreezSDKLiquid {
     _instance = null;
   }
 
-  Future<void> _fetchWalletData(liquid_sdk.BindingLiquidSdk sdk) async {
+  Future<void> _fetchWalletData(liquid_sdk.BreezSdkLiquid sdk) async {
     await _getInfo(sdk);
     await _listPayments(sdk: sdk);
   }
 
-  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BindingLiquidSdk sdk) async {
+  Future<liquid_sdk.GetInfoResponse> _getInfo(liquid_sdk.BreezSdkLiquid sdk) async {
     final walletInfo = await sdk.getInfo();
     _walletInfoController.add(walletInfo);
     return walletInfo;
   }
 
   Future<List<liquid_sdk.Payment>> _listPayments({
-    required liquid_sdk.BindingLiquidSdk sdk,
+    required liquid_sdk.BreezSdkLiquid sdk,
   }) async {
     const req = liquid_sdk.ListPaymentsRequest();
     final paymentsList = await sdk.listPayments(req: req);
@@ -76,12 +75,12 @@ class BreezSDKLiquid {
 
   Stream<liquid_sdk.SdkEvent>? _breezEventsStream;
 
-  void _initializeEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+  void _initializeEventsStream(liquid_sdk.BreezSdkLiquid sdk) {
     _breezEventsStream ??= sdk.addEventListener().asBroadcastStream();
   }
 
   /// Subscribes to SDK's event & log streams.
-  void _subscribeToSdkStreams(liquid_sdk.BindingLiquidSdk sdk) {
+  void _subscribeToSdkStreams(liquid_sdk.BreezSdkLiquid sdk) {
     _subscribeToEventsStream(sdk);
     _subscribeToLogStream();
   }
@@ -102,7 +101,7 @@ class BreezSDKLiquid {
 
   /* TODO: Liquid - Log statements are added for debugging purposes, should be removed after early development stage is complete & events are behaving as expected.*/
   /// Subscribes to SdkEvent's stream
-  void _subscribeToEventsStream(liquid_sdk.BindingLiquidSdk sdk) {
+  void _subscribeToEventsStream(liquid_sdk.BreezSdkLiquid sdk) {
     _breezEventsSubscription = _breezEventsStream?.listen(
       (event) async {
         if (event is liquid_sdk.SdkEvent_PaymentFailed) {
@@ -179,18 +178,18 @@ class PaymentException {
 
 extension ConfigCopyWith on liquid_sdk.Config {
   liquid_sdk.Config copyWith({
-    BlockchainExplorer? liquidExplorer,
-    BlockchainExplorer? bitcoinExplorer,
-    String? mempoolspaceUrl,
+    liquid_sdk.BlockchainExplorer? liquidExplorer,
+    liquid_sdk.BlockchainExplorer? bitcoinExplorer,
     String? workingDir,
     liquid_sdk.LiquidNetwork? network,
     BigInt? paymentTimeoutSec,
-    int? zeroConfMinFeeRateMsat,
     String? syncServiceUrl,
+    BigInt? zeroConfMaxAmountSat,
+    String? breezApiKey,
     List<liquid_sdk.ExternalInputParser>? externalInputParsers,
     bool? useDefaultExternalInputParsers,
     List<liquid_sdk.AssetMetadata>? assetMetadata,
-    String? breezApiKey,
+    String? sideswapApiKey,
     bool? useMagicRoutingHints,
   }) {
     return liquid_sdk.Config(
@@ -200,10 +199,12 @@ extension ConfigCopyWith on liquid_sdk.Config {
       network: network ?? this.network,
       paymentTimeoutSec: paymentTimeoutSec ?? this.paymentTimeoutSec,
       syncServiceUrl: syncServiceUrl ?? this.syncServiceUrl,
-      useDefaultExternalInputParsers: useDefaultExternalInputParsers ?? this.useDefaultExternalInputParsers,
-      externalInputParsers: externalInputParsers ?? this.externalInputParsers,
-      assetMetadata: assetMetadata ?? this.assetMetadata,
+      zeroConfMaxAmountSat: zeroConfMaxAmountSat ?? this.zeroConfMaxAmountSat,
       breezApiKey: breezApiKey ?? this.breezApiKey,
+      externalInputParsers: externalInputParsers ?? this.externalInputParsers,
+      useDefaultExternalInputParsers: useDefaultExternalInputParsers ?? this.useDefaultExternalInputParsers,
+      assetMetadata: assetMetadata ?? this.assetMetadata,
+      sideswapApiKey: sideswapApiKey ?? this.sideswapApiKey,
       useMagicRoutingHints: useMagicRoutingHints ?? this.useMagicRoutingHints,
     );
   }

--- a/snippets/dart_snippets/lib/send_payment.dart
+++ b/snippets/dart_snippets/lib/send_payment.dart
@@ -13,8 +13,10 @@ Future<LightningPaymentLimitsResponse> getCurrentLightningLimits() async {
 Future<PrepareSendResponse> prepareSendPaymentLightningBolt11() async {
   // ANCHOR: prepare-send-payment-lightning-bolt11
   // Set the bolt11 invoice you wish to pay
+  PrepareSendRequest prepareSendRequest = PrepareSendRequest(destination: "<bolt11 invoice>");
+
   PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
-    req: PrepareSendRequest(destination: "<bolt11 invoice>"),
+    req: prepareSendRequest,
   );
 
   // If the fees are acceptable, continue to create the Send Payment
@@ -28,11 +30,13 @@ Future<PrepareSendResponse> prepareSendPaymentLightningBolt12() async {
   // ANCHOR: prepare-send-payment-lightning-bolt12
   // Set the bolt12 offer you wish to pay
   PayAmount_Bitcoin optionalAmount = PayAmount_Bitcoin(receiverAmountSat: 5000 as BigInt);
+  PrepareSendRequest prepareSendRequest = PrepareSendRequest(
+    destination: "<bolt12 offer>",
+    amount: optionalAmount,
+  );
+
   PrepareSendResponse prepareSendResponse = await breezSDKLiquid.instance!.prepareSendPayment(
-    req: PrepareSendRequest(
-      destination: "<bolt12 offer>",
-      amount: optionalAmount,
-    ),
+    req: prepareSendRequest,
   );
   // ANCHOR_END: prepare-send-payment-lightning-bolt12
   return prepareSendResponse;
@@ -81,11 +85,13 @@ Future<PrepareSendResponse> prepareSendPaymentLiquidDrain() async {
 Future<SendPaymentResponse> sendPayment({required PrepareSendResponse prepareResponse}) async {
   // ANCHOR: send-payment
   String optionalPayerNote = "<payer note>";
+  SendPaymentRequest sendPaymentRequest = SendPaymentRequest(
+    prepareResponse: prepareResponse,
+    payerNote: optionalPayerNote,
+  );
+
   SendPaymentResponse sendPaymentResponse = await breezSDKLiquid.instance!.sendPayment(
-    req: SendPaymentRequest(
-      prepareResponse: prepareResponse,
-      payerNote: optionalPayerNote,
-    ),
+    req: sendPaymentRequest,
   );
   Payment payment = sendPaymentResponse.payment;
   // ANCHOR_END: send-payment

--- a/snippets/dart_snippets/lib/webhook.dart
+++ b/snippets/dart_snippets/lib/webhook.dart
@@ -2,8 +2,8 @@ import 'package:dart_snippets/sdk_instance.dart';
 
 Future<void> registerWebhook() async {
   // ANCHOR: register-webook
-  await breezSDKLiquid.instance!
-      .registerWebhook(webhookUrl: "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>");
+  String webhookUrl = "https://your-nds-service.com/api/v1/notify?platform=ios&token=<PUSH_TOKEN>";
+  await breezSDKLiquid.instance!.registerWebhook(webhookUrl: webhookUrl);
   // ANCHOR_END: register-webook
 }
 

--- a/snippets/dart_snippets/pubspec.lock
+++ b/snippets/dart_snippets/pubspec.lock
@@ -5,18 +5,18 @@ packages:
     dependency: transitive
     description:
       name: _fe_analyzer_shared
-      sha256: da0d9209ca76bde579f2da330aeb9df62b6319c834fa7baae052021b0462401f
+      sha256: dd3d2ad434b9510001d089e8de7556d50c834481b9abc2891a0184a8493a19dc
       url: "https://pub.dev"
     source: hosted
-    version: "85.0.0"
+    version: "89.0.0"
   analyzer:
     dependency: transitive
     description:
       name: analyzer
-      sha256: d10f9c2bf877706e39e9cc94d89ba28c7084f6e3529b4a2a96bb474fd0323647
+      sha256: c22b6e7726d1f9e5db58c7251606076a71ca0dbcf76116675edfadbec0c9e875
       url: "https://pub.dev"
     source: hosted
-    version: "7.5.5"
+    version: "8.2.0"
   app_group_directory:
     dependency: "direct main"
     description:
@@ -49,23 +49,14 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.2"
-  breez_liquid:
-    dependency: "direct main"
-    description:
-      path: "."
-      ref: "v0.11.2"
-      resolved-ref: "5e0421ffabbf0695a44e02c9dd81bf5ef50e61e8"
-      url: "https://github.com/breez/breez-sdk-liquid-dart"
-    source: git
-    version: "0.11.2"
   build_cli_annotations:
     dependency: transitive
     description:
       name: build_cli_annotations
-      sha256: b59d2769769efd6c9ff6d4c4cede0be115a566afc591705c2040b707534b1172
+      sha256: e563c2e01de8974566a1998410d3f6f03521788160a02503b0b1f1a46c7b3d95
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.0"
+    version: "2.1.1"
   characters:
     dependency: transitive
     description:
@@ -82,14 +73,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "0.2.0"
-  cli_util:
-    dependency: transitive
-    description:
-      name: cli_util
-      sha256: ff6785f7e9e3c38ac98b2fb035701789de90154024a75b6cb926445e83197d1c
-      url: "https://pub.dev"
-    source: hosted
-    version: "0.4.2"
   collection:
     dependency: transitive
     description:
@@ -110,10 +93,10 @@ packages:
     dependency: transitive
     description:
       name: coverage
-      sha256: aa07dbe5f2294c827b7edb9a87bba44a9c15a3cc81bc8da2ca19b37322d30080
+      sha256: "5da775aa218eaf2151c721b16c01c7676fbfdd99cebba2bf64e8b807a28ff94d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.14.1"
+    version: "1.15.0"
   crypto:
     dependency: transitive
     description:
@@ -122,14 +105,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.0.6"
-  dart_style:
-    dependency: transitive
-    description:
-      name: dart_style
-      sha256: "5b236382b47ee411741447c1f1e111459c941ea1b3f2b540dde54c210a3662af"
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.1.0"
   ffi:
     dependency: transitive
     description:
@@ -138,14 +113,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.1.4"
-  ffigen:
-    dependency: transitive
-    description:
-      name: ffigen
-      sha256: "72d732c33557fc0ca9b46379d3deff2dadbdc539696dc0b270189e2989be20ef"
-      url: "https://pub.dev"
-    source: hosted
-    version: "18.1.0"
   file:
     dependency: transitive
     description:
@@ -163,11 +130,11 @@ packages:
     dependency: "direct main"
     description:
       path: "."
-      ref: "v0.11.2"
-      resolved-ref: "3d68e8de972ef24cde21ce276776ae26c9b78df4"
+      ref: "v0.11.3-dev7"
+      resolved-ref: "70d72a5de09d5fa9cd114bb79796515eab92c2f1"
       url: "https://github.com/breez/breez-sdk-liquid-flutter"
     source: git
-    version: "0.11.2"
+    version: "0.11.3-dev7"
   flutter_rust_bridge:
     dependency: transitive
     description:
@@ -377,18 +344,18 @@ packages:
     dependency: transitive
     description:
       name: path_provider_android
-      sha256: d0d310befe2c8ab9e7f393288ccbb11b60c019c6b5afc21973eeee4dda2b35e9
+      sha256: "993381400e94d18469750e5b9dcb8206f15bc09f9da86b9e44a9b0092a0066db"
       url: "https://pub.dev"
     source: hosted
-    version: "2.2.17"
+    version: "2.2.18"
   path_provider_foundation:
     dependency: transitive
     description:
       name: path_provider_foundation
-      sha256: "4843174df4d288f5e29185bd6e72a6fbdf5a4a4602717eed565497429f179942"
+      sha256: "16eef174aacb07e09c351502740fa6254c165757638eba1e9116b0a781201bbd"
       url: "https://pub.dev"
     source: hosted
-    version: "2.4.1"
+    version: "2.4.2"
   path_provider_linux:
     dependency: transitive
     description:
@@ -433,10 +400,10 @@ packages:
     dependency: transitive
     description:
       name: pool
-      sha256: "20fe868b6314b322ea036ba325e6fc0711a22948856475e2c2b6306e8ab39c2a"
+      sha256: "978783255c543aa3586a1b3c21f6e9d720eb315376a915872c61ef8b5c20177d"
       url: "https://pub.dev"
     source: hosted
-    version: "1.5.1"
+    version: "1.5.2"
   pub_semver:
     dependency: transitive
     description:
@@ -445,14 +412,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "2.2.0"
-  quiver:
-    dependency: transitive
-    description:
-      name: quiver
-      sha256: ea0b925899e64ecdfbf9c7becb60d5b50e706ade44a85b2363be2a22d88117d2
-      url: "https://pub.dev"
-    source: hosted
-    version: "3.2.2"
   rxdart:
     dependency: "direct main"
     description:
@@ -558,26 +517,26 @@ packages:
     dependency: "direct dev"
     description:
       name: test
-      sha256: "65e29d831719be0591f7b3b1a32a3cda258ec98c58c7b25f7b84241bc31215bb"
+      sha256: "75906bf273541b676716d1ca7627a17e4c4070a3a16272b7a3dc7da3b9f3f6b7"
       url: "https://pub.dev"
     source: hosted
-    version: "1.26.2"
+    version: "1.26.3"
   test_api:
     dependency: transitive
     description:
       name: test_api
-      sha256: "522f00f556e73044315fa4585ec3270f1808a4b186c936e612cab0b565ff1e00"
+      sha256: ab2726c1a94d3176a45960b6234466ec367179b87dd74f1611adb1f3b5fb9d55
       url: "https://pub.dev"
     source: hosted
-    version: "0.7.6"
+    version: "0.7.7"
   test_core:
     dependency: transitive
     description:
       name: test_core
-      sha256: "80bf5a02b60af04b09e14f6fe68b921aad119493e26e490deaca5993fef1b05a"
+      sha256: "0cc24b5ff94b38d2ae73e1eb43cc302b77964fbf67abad1e296025b78deb53d0"
       url: "https://pub.dev"
     source: hosted
-    version: "0.6.11"
+    version: "0.6.12"
   typed_data:
     dependency: transitive
     description:
@@ -590,10 +549,10 @@ packages:
     dependency: transitive
     description:
       name: vector_math
-      sha256: "80b3257d1492ce4d091729e3a67a60407d227c27241d6927be0130c98e741803"
+      sha256: d530bd74fea330e6e364cda7a85019c434070188383e1cd8d9777ee586914c5b
       url: "https://pub.dev"
     source: hosted
-    version: "2.1.4"
+    version: "2.2.0"
   vm_service:
     dependency: transitive
     description:
@@ -606,10 +565,10 @@ packages:
     dependency: transitive
     description:
       name: watcher
-      sha256: "0b7fd4a0bbc4b92641dbf20adfd7e3fd1398fe17102d94b674234563e110088a"
+      sha256: "5bf046f41320ac97a469d506261797f35254fa61c641741ef32dacda98b7d39c"
       url: "https://pub.dev"
     source: hosted
-    version: "1.1.2"
+    version: "1.1.3"
   web:
     dependency: transitive
     description:
@@ -658,14 +617,6 @@ packages:
       url: "https://pub.dev"
     source: hosted
     version: "3.1.3"
-  yaml_edit:
-    dependency: transitive
-    description:
-      name: yaml_edit
-      sha256: fb38626579fb345ad00e674e2af3a5c9b0cc4b9bfb8fd7f7ff322c7c9e62aef5
-      url: "https://pub.dev"
-    source: hosted
-    version: "2.2.2"
 sdks:
-  dart: ">=3.7.0 <4.0.0"
-  flutter: ">=3.27.0"
+  dart: ">=3.9.0 <4.0.0"
+  flutter: ">=3.29.0"

--- a/snippets/dart_snippets/pubspec.yaml
+++ b/snippets/dart_snippets/pubspec.yaml
@@ -13,14 +13,10 @@ dependencies:
   flutter_secure_storage: ^6.0.0
   app_group_directory: ^2.0.0
   path_provider: ^2.0.0
-  breez_liquid:
-    git:
-      url: https://github.com/breez/breez-sdk-liquid-dart
-      ref: v0.11.2
   flutter_breez_liquid:
     git:
       url: https://github.com/breez/breez-sdk-liquid-flutter
-      ref: v0.11.2
+      ref: v0.11.3-dev7
   rxdart: ^0.28.0
 
 dependency_overrides:


### PR DESCRIPTION
This PR updates Dart snippets to align with `flutter_breez_liquid` after migrating to the new Cargokit-based architecture.

#### Changelist:
- **Breaking**: `BindingLiquidSdk` renamed to `BreezSdkLiquid`
- **Breaking**: `initialize()` is now `FlutterBreezLiquid.init()`
- Refactored snippets for consistency:
  - Extracted request objects into variables
  - Added spacing between request objects and API calls
- Updated log stream initialization on Android to include NSE logs